### PR TITLE
Logplex Shard commits do not update URL cache

### DIFF
--- a/src/logplex_shard.erl
+++ b/src/logplex_shard.erl
@@ -106,7 +106,9 @@ handle_call({commit, new_shard_info}, _From, State) ->
     backup_shard_info(),
     try
         make_new_shard_info_permanent(),
-        {reply, ok, State}
+        Map = dict:to_list(element(1,logplex_shard_info:read(?CURRENT_WRITE_MAP))),
+        Urls = logplex_shard:redis_sort([URL || {_Inter, {URL, _Pid}} <- Map]),
+        {reply, ok, State#state{urls=Urls}}
     catch C:E ->
             revert_shard_info(),
             {reply, {error, {C, E}}, State}


### PR DESCRIPTION
The cache that can be obtained with logplex_shard:urls() is not updated
when committing a replacement shard successfully. This can lead to
confusing subsequent calls if nodes have been removed in ETS tables but
the operator still uses urls/0 to create the new shard list.

This patch makes sure that the url cache is update using the
?CURRENT_WRITE_MAP table, which should be similar to the read pool given
the current implementation.
