### PR TITLE
Nosuspend port buffer

### DIFF
--- a/src/logplex_tcpsyslog_drain.erl
+++ b/src/logplex_tcpsyslog_drain.erl
@@ -566,6 +566,8 @@ send(State = #state{buf = Buf, sock = Sock,
                                    "err=gen_tcp data=~p sock=~p duration=~s",
                                    log_info(State, [send, port_dropped, Sock,
                                                     duration(State)])),
+                             msg_stat(drain_dropped, N, State),
+                             logplex_realtime:incr(drain_dropped, N),
                              {next_state, ready_to_send, State#state{buf=NewBuf}};
                     _ -> Ref = erlang:start_timer(?SEND_TIMEOUT, self(),
                                                   ?SEND_TIMEOUT_MSG),


### PR DESCRIPTION
Hopefully this will address the OOMs we're seeing on logplex.

I think in this case it's appropriate to just log the failure; the data is lost, but we should be able to move on.
