### PR TITLE
Disable logplex_stats's caching of its ets table.

### DIFF
--- a/src/logplex_stats.erl
+++ b/src/logplex_stats.erl
@@ -118,7 +118,7 @@ handle_info({timeout, _TimerRef, flush}, _State) ->
          V =/= 0],
 
     start_timer(),
-    {noreply, stats_disabled};
+    {noreply, stats_cache_disabled};
 
 handle_info(_Info, State) ->
     {noreply, State}.


### PR DESCRIPTION
This gen_server is currently consuming the most memory of all
processes in production by a fairly large margin.
