### PR TITLE
Add localized channel ring buffer monitoring

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cd $(dirname $0)/..
+
+INSTANCE_NAME=`hostname` \
+    LOGPLEX_CONFIG_REDIS_URL="redis://localhost:6379" \
+    LOGPLEX_SHARD_URLS="redis://localhost:6379" \
+    LOGPLEX_REDGRID_REDIS_URL="redis://localhost:6379" \
+    LOCAL_IP="127.0.0.1" \
+    LOGPLEX_COOKIE=123 \
+    ERL_LIBS=`pwd`/deps/ \
+    ct_run -spec logplex.spec -pa ebin

--- a/bin/test_suite
+++ b/bin/test_suite
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+cd $(dirname $0)/..
+
+./rebar compile skip_deps=true && INSTANCE_NAME=`hostname` \
+    LOGPLEX_CONFIG_REDIS_URL="redis://localhost:6379" \
+    LOGPLEX_SHARD_URLS="redis://localhost:6379" \
+    LOGPLEX_STATS_REDIS_URL="redis://localhost:6379" \
+    LOGPLEX_REDGRID_REDIS_URL="redis://localhost:6379" \
+    LOCAL_IP="127.0.0.1" \
+    LOGPLEX_COOKIE=123 \
+    ERL_LIBS=`pwd`/deps/ \
+    LOGPLEX_CLOUD_NAME=dev \
+    ct_run -dir test -suite $1 -logdir logs -pa ebin -include include

--- a/src/logplex_message.erl
+++ b/src/logplex_message.erl
@@ -67,8 +67,8 @@ process_tails(ChannelId, Msg) ->
     logplex_tail:route(ChannelId, Msg).
 
 process_redis(ChannelId, ShardInfo, Msg) ->
-    case logplex_channel:lookup_flag(no_redis, ChannelId) of
-        no_redis -> ok;
+    case logplex_channel:is_flagged([no_redis, no_redis_local], ChannelId) of
+        true -> ok;
         _ ->
             Expiry = logplex_app:config(redis_buffer_expiry),
             HistorySize = logplex_app:config(log_history),

--- a/src/logplex_worker.erl
+++ b/src/logplex_worker.erl
@@ -110,8 +110,8 @@ process_tails(ChannelId, Msg) ->
     ok.
 
 process_msg(ChannelId, State, Msg) ->
-    case logplex_channel:lookup_flag(no_redis, ChannelId) of
-        no_redis -> ok;
+    case logplex_channel:is_flagged([no_redis, no_redis_local], ChannelId) of
+        true -> ok;
         _ ->
             Expiry = logplex_app:config(redis_buffer_expiry),
             HistorySize = logplex_app:config(log_history),

--- a/test.rebar.config
+++ b/test.rebar.config
@@ -17,5 +17,5 @@
  ,{batchio, "", {git, "git://github.com/ferd/batchio.git", "master"}}
  ,{recon, "", {git, "git://github.com/ferd/recon.git", "master"}}
 %% TESTS ONLY
- ,{meck, "", {git, "git://github.com/eproxus/meck.git", "0.7.2"}}
+ ,{meck, "", {git, "git://github.com/eproxus/meck.git", "0.8.1"}}
  ]}.

--- a/test/logplex_channel_SUITE.erl
+++ b/test/logplex_channel_SUITE.erl
@@ -16,7 +16,7 @@
 %% a single atom.
 
 all() ->
-    [properties].
+    [properties, flags_to_binary, is_flagged].
 
 %%%%%%%%%%%%%%%%%%%%%%
 %%% Setup/Teardown %%%
@@ -70,6 +70,23 @@ properties(_Config) ->
     ok = recv_msg({rec, {post, Msg2}}),
     %% The process should be down
     [] = logplex_channel:whereis(Channel).
+
+flags_to_binary(_Config) ->
+    Flags = ['no_redis', 'no_tail', 'no_redis_local'],
+    <<"no_redis:no_tail">> = logplex_channel:flags_to_binary(Flags).
+
+is_flagged(_Config) ->
+    ChannelId = 2189312,
+    ChannelName = <<"test">>,
+    logplex_channel:create_ets_table(),
+    logplex_channel:cache(ChannelId, ChannelName, []),
+    false = logplex_channel:is_flagged([no_redis], ChannelId),
+    logplex_channel:cache(ChannelId, ChannelName, [no_redis, no_tail]),
+    true = logplex_channel:is_flagged([no_redis], ChannelId),
+    logplex_channel:cache(ChannelId, ChannelName, [no_tail]),
+    false = logplex_channel:is_flagged([no_redis], ChannelId),
+    logplex_channel:cache(ChannelId, ChannelName, [no_redis, no_tail, no_redis_local]),
+    true = logplex_channel:is_flagged([no_redis, no_redis_local], ChannelId).
 
 %%%%%%%%%%%%%%%
 %%% PRIVATE %%%

--- a/test/logplex_stats_SUITE.erl
+++ b/test/logplex_stats_SUITE.erl
@@ -1,0 +1,71 @@
+-module(logplex_stats_SUITE).
+-include_lib("common_test/include/ct.hrl").
+-include_lib("logplex/include/logplex.hrl").
+-compile(export_all).
+
+all() -> [channel_flood].
+
+init_per_suite(Config) ->
+    set_os_vars(),
+    ok = logplex_app:a_start(logplex, temporary),
+    Config.
+
+end_per_suite(_Config) ->
+    application:stop(logplex),
+    meck:unload().
+
+init_per_testcase(_, Config) ->
+    application:set_env(logplex, channel_flood_msg_threshold, 2),
+    application:set_env(logplex, channel_flood_flap_threshold, 2),
+    ChannelId = 1337,
+    [{channel, ChannelId} | Config].
+
+end_per_testcase(_, _Config) ->
+    ok.
+
+%%% Setup & teardown helpers %%%
+set_os_vars() ->
+    [os:putenv(Key,Val) || {Key,Val} <-
+        [{"INSTANCE_NAME", "localhost"},
+         {"LOCAL_IP", "localhost"},
+         {"CLOUD_DOMAIN", "localhost"},
+         {"LOGPLEX_AUTH_KEY", uuid:to_string(uuid:v4())},
+         {"LOGPLEX_COOKIE", "ct test"}
+        ]],
+    logplex_app:cache_os_envvars().
+
+%%%%%%%%%%%%%
+%%% TESTS %%%
+%%%%%%%%%%%%%
+channel_flood(Config) ->
+    meck:new(logplex_channel, [passthrough, no_link]),
+    meck:expect(logplex_channel, set_local_flag, fun(_, _) -> ok end),
+    meck:expect(logplex_channel, unset_local_flag, fun(_, _) -> ok end),
+    ChannelId = ?config(channel, Config),
+    flush_logs(),
+    logplex_stats:incr(#channel_stat{channel_id=ChannelId}, 1),
+    logplex_stats:incr(#channel_stat{channel_id=ChannelId}, 1),
+    flush_logs(),
+    logplex_stats:incr(#channel_stat{channel_id=ChannelId}, 1),
+    logplex_stats:incr(#channel_stat{channel_id=ChannelId}, 1),
+    flush_logs(),
+    logplex_stats:incr(#channel_stat{channel_id=ChannelId}, 1),
+    logplex_stats:incr(#channel_stat{channel_id=ChannelId}, 1), % triggers flood
+    flush_logs(),
+    1 = meck:num_calls(logplex_channel, set_local_flag, [ChannelId, no_redis_local]),
+    meck:reset(logplex_channel),
+    logplex_stats:incr(#channel_stat{channel_id=ChannelId}, 1),
+    flush_logs(),
+    logplex_stats:incr(#channel_stat{channel_id=ChannelId}, 1),
+    flush_logs(),
+    logplex_stats:incr(#channel_stat{channel_id=ChannelId}, 1),
+    flush_logs(),
+    1 = meck:num_calls(logplex_channel, unset_local_flag, [ChannelId, no_redis_local]).
+
+fake_msg(M) ->
+    {user, debug, logplex_syslog_utils:datetime(now), "fakehost", "erlang", M}.
+
+flush_logs() ->
+    logplex_stats ! {timeout, make_ref(), flush},
+    timer:sleep(100).
+


### PR DESCRIPTION
One of the main sources of load for Logplex is getting log messages into
the Redis ring buffer in order for some backlog to be visible when a
customer requests their log tail. For apps which produce a reasonable
amount of data this works fine, but for apps which produce an excessive
amount of log data, it is both unnecessary and time-consuming to store
these log messages in Redis, because there's no need for a backlog when
simply watching the tail for a few seconds will give you plenty of data.

This commit adds node localized monitoring of the messages being sent to
the Redis ring buffer. A new flag `no_redis_local` has been to control
the automated channel monitoring. Localized monitoring has been added in
such a way that it does not intefere with existing global channel flags.
In fact setting either `no_tail` or `no_redis` will take precedence and
remove any localized flags that existed on the channel.

There are two application environment variables that can be set to
control the behaviour of this monitoring.

- `channel_flood_msg_threshold` The messages per second required to
trigger flagging a channel as being flooded.
- `channel_flood_flap_threshold` The number of consecutive flooding
notices required before actually setting the `no_redis_local` flag on
the channel.

The latter environment variable helps control flapping situations and
has been inplemented in such a way that if it requires 3 consecutive
flood notices before taking action, then the system must also receive 3
consecutive notices of normal flow before disabling the `no_redis_local`
flag.

A couple tooling utilities were added to help with running the test
suites. These are only slightly modified versions of some tools Phil was
already using so credits for the bin scripts should go to him.

Additionally there are a few outstanding items that should be taken
care of or added. Those are:

- The `logplex_worker` and `logplex_message` modules were modified but
not directly tested.
- An additional stat record should be added to record the number of
times the msg threshold is crossed and the number of times the actual
`no_redis_local` flag is set on a channel. Some interesting stats could
be gathered to see how the automated system is performing and how it
could be tuned.