### PR TITLE
Add a firehose channel

### DIFF
--- a/src/logplex_app.erl
+++ b/src/logplex_app.erl
@@ -75,6 +75,7 @@ stop(_State) ->
     ok.
 
 start_phase(listen, normal, _Args) ->
+    setup_firehose(),
     {ok, _} = supervisor:start_child(logplex_sup,
                                      logplex_api:child_spec()),
     {ok, _} = supervisor:start_child(logplex_sup,
@@ -98,6 +99,10 @@ cache_os_envvars() ->
                       ,{metrics_channel_id, ["METRICS_CHANNEL_ID"],
                         optional,
                         integer}
+                      ,{firehose_channel_ids, ["FIREHOSE_CHANNEL_IDS"],
+                        optional}
+                      ,{firehose_filter_tokens, ["FIREHOSE_FILTER_TOKENS"],
+                        optional}
                       ,{local_ip, ["LOCAL_IP"]}
                       ,{metrics_namespace, ["METRICS_NAMESPACE"],
                         optional}
@@ -217,6 +222,9 @@ setup_redis_shards() ->
            end,
     application:set_env(logplex, logplex_shard_urls,
                         logplex_shard:redis_sort(URLs)).
+
+setup_firehose() ->
+    logplex_firehose:enable().
 
 logplex_work_queue_args() ->
     MaxLength = logplex_utils:to_int(config(queue_length)),

--- a/src/logplex_db.erl
+++ b/src/logplex_db.erl
@@ -45,6 +45,7 @@ create_ets_tables() ->
     logplex_drain:create_ets_table(),
     logplex_cred:create_ets_table(),
     logplex_session:create_ets_table(),
+    logplex_firehose:create_ets_tables(),
     ok.
 
 -spec poll(fun ( () -> 'not_found' | {'found', T} | {'error', E} ),

--- a/src/logplex_firehose.erl
+++ b/src/logplex_firehose.erl
@@ -1,0 +1,140 @@
+%% Copyright (c) 2014 Alex Arnell <alex@heroku.com>
+%%
+%% Permission is hereby granted, free of charge, to any person
+%% obtaining a copy of this software and associated documentation
+%% files (the "Software"), to deal in the Software without
+%% restriction, including without limitation the rights to use,
+%% copy, modify, merge, publish, distribute, sublicense, and/or sell
+%% copies of the Software, and to permit persons to whom the
+%% Software is furnished to do so, subject to the following
+%% conditions:
+%%
+%% The above copyright notice and this permission notice shall be
+%% included in all copies or substantial portions of the Software.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+%% EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+%% OF MERCHANLOOKUP_TABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+%% NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+%% HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+%% WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+%% FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+%% OTHER DEALINGS IN THE SOFTWARE.
+-module(logplex_firehose).
+
+-include("logplex.hrl").
+-include("logplex_logging.hrl").
+
+-define(MASTER_TAB, firehose_master).
+-define(SHARD_TAB, firehose_shards).
+
+-export([next_shard/2,
+         post_msg/3]).
+
+-export([create_ets_tables/0,
+         enable/0,
+         disable/0]).
+
+-export([firehose_channel_ids/0,
+         firehose_filter_tokens/0]).
+
+-record(shard_pool, {key=master_shard,
+                     size=0 :: integer(),
+                     pool={} :: tuple()}).
+-record(shard, {id :: {integer(), binary()},
+                channel_id :: logplex_channel:id() }).
+
+%%%--------------------------------------------------------------------
+%%% API
+%%%--------------------------------------------------------------------
+
+create_ets_tables() ->
+    ets:new(?MASTER_TAB, [named_table, public, set,
+                              {keypos, #shard_pool.key},
+                              {read_concurrency, true}]),
+    ets:new(?SHARD_TAB, [named_table, public, set,
+                              {keypos, #shard.id},
+                              {read_concurrency, true}]),
+    [?MASTER_TAB, ?SHARD_TAB].
+
+next_shard(ChannelId, Token) 
+  when is_integer(ChannelId),
+       is_binary(Token) ->
+    lookup_shard({next_hash(ChannelId), Token}).
+
+post_msg(SourceId, TokenName, Msg)
+  when is_integer(SourceId),
+       is_binary(TokenName) ->
+    case next_shard(SourceId, TokenName) of
+        undefined -> ok; % no shards, drop
+        SourceId -> ok; % do not firehose a firehose
+        ChannelId when is_integer(ChannelId) ->
+            logplex_channel:post_msg({channel, ChannelId}, Msg)
+    end.
+
+enable() ->
+    ChannelIds = firehose_channel_ids(),
+    FilterTokens = firehose_filter_tokens(),
+    store_master_info(ChannelIds),
+    store_channels(ChannelIds, FilterTokens),
+    ok.
+
+disable() ->
+    store_master_info([]),
+    ets:delete_all_objects(?SHARD_TAB),
+    ok.
+
+%%%--------------------------------------------------------------------
+%%% private functions
+%%%--------------------------------------------------------------------
+
+compute_hash(_, 0) ->
+    0;
+compute_hash(ChannelId, Bounds) ->
+    erlang:phash2({os:timestamp(), self(), ChannelId}, Bounds) + 1.
+
+firehose_channel_ids() ->
+    [ list_to_integer(Id) || Id <- split_list(firehose_channel_ids) ].
+
+firehose_filter_tokens() ->
+    [ list_to_binary(Token) || Token <- split_list(firehose_filter_tokens) ].
+
+split_list(Env) ->
+    case logplex_app:config(Env, []) of
+        [] -> [];
+        Ids when is_list(Ids) ->
+            string:tokens(Ids, ",")
+    end.
+
+
+lookup_shard({0, _}) ->
+    undefined;
+lookup_shard(ShardId) ->
+    try ets:lookup_element(?SHARD_TAB, ShardId, #shard.channel_id) of
+        ChannelId -> ChannelId
+    catch error:badarg -> undefined
+    end.
+
+next_hash(ChannelId) ->
+    try ets:lookup_element(?MASTER_TAB, master_shard, #shard_pool.size) of
+        Num -> compute_hash(ChannelId, Num)
+    catch error:badarg -> 0
+    end.
+
+store_master_info(ChannelIds) ->
+    ets:insert(?MASTER_TAB,
+               #shard_pool{size=length(ChannelIds),
+                           pool=ChannelIds}).
+
+store_channels(ChannelIds, FilterTokens) ->
+    ShardIds = lists:zip(lists:seq(1, length(ChannelIds)), ChannelIds),
+    Shards = [ #shard{id={Idx, Token}, channel_id=ChannelId}
+               || {Idx, ChannelId} <- ShardIds, Token <- FilterTokens ],
+    store_channels(Shards).
+
+store_channels([]) ->
+    ok;
+store_channels([Shard | Rest]) ->
+    ets:insert(?SHARD_TAB, Shard),
+    store_channels(Rest).
+

--- a/src/logplex_message.erl
+++ b/src/logplex_message.erl
@@ -56,6 +56,7 @@ process_msg(RawMsg, ChannelId, Token, TokenName, ShardInfo)
     logplex_stats:incr(message_received),
     logplex_realtime:incr(message_received),
     CookedMsg = iolist_to_binary(re:replace(RawMsg, Token, TokenName)),
+    logplex_firehose:post_msg(ChannelId, TokenName, RawMsg),
     process_drains(ChannelId, CookedMsg),
     process_tails(ChannelId, CookedMsg),
     process_redis(ChannelId, ShardInfo, CookedMsg).

--- a/src/logplex_worker.erl
+++ b/src/logplex_worker.erl
@@ -89,6 +89,7 @@ route(Token, State = #state{}, RawMsg)
     case logplex_token:lookup(Token) of
         #token{channel_id=ChannelId, name=TokenName} ->
             CookedMsg = iolist_to_binary(re:replace(RawMsg, Token, TokenName)),
+            logplex_firehose:post_msg(ChannelId, TokenName, RawMsg),
             process_drains(ChannelId, CookedMsg),
             process_tails(ChannelId, CookedMsg),
             process_msg(ChannelId, State, CookedMsg);

--- a/src/nsync_callback.erl
+++ b/src/nsync_callback.erl
@@ -120,7 +120,11 @@ handle({cmd, _Cmd, [<<"redgrid", _/binary>>|_]}) ->
 
 handle({cmd, _Cmd, [<<"stats", _/binary>>|_]}) ->
     ok;
-
+handle({cmd, Cmd, [<<"ch:", _/binary>> | _]})
+  when Cmd =:= "lpush";
+       Cmd =:= "ltrim";
+       Cmd =:= "expire" ->
+    ok;
 handle({cmd, "incr", [<<"channel_index", _/binary>> | _]}) ->
     %% ignore the channel_index traffic
     ok;

--- a/test.rebar.config
+++ b/test.rebar.config
@@ -17,5 +17,5 @@
  ,{batchio, "", {git, "git://github.com/ferd/batchio.git", "master"}}
  ,{recon, "", {git, "git://github.com/ferd/recon.git", "master"}}
 %% TESTS ONLY
- ,{meck, "", {git, "git://github.com/eproxus/meck.git", "0.7.2"}}
+ ,{meck, "", {git, "git://github.com/eproxus/meck.git", "0.8.2"}}
  ]}.

--- a/test/logplex_firehose_SUITE.erl
+++ b/test/logplex_firehose_SUITE.erl
@@ -1,0 +1,147 @@
+%%%-------------------------------------------------------------------
+%% @copyright Heroku, 2014
+%% @author Alex Arnell <alex@heroku.com>
+%% @doc CommonTest test suite for logplex_firehose
+%% @end
+%%%-------------------------------------------------------------------
+
+-module(logplex_firehose_SUITE).
+-include_lib("common_test/include/ct.hrl").
+-compile(export_all).
+
+all() ->
+    [master_config, post_msg, distribution].
+
+%%%%%%%%%%%%%%%%%%%%%%
+%%% Setup/Teardown %%%
+%%%%%%%%%%%%%%%%%%%%%%
+%% Runs once at the beginning of the suite. The process is different
+%% from the one the case will run in.
+init_per_suite(Config) ->
+    Config.
+
+%% Runs once at the end of the suite. The process is different
+%% from the one the case will run in.
+end_per_suite(Config) ->
+    Config.
+
+%% Runs before the test case. Runs in the same process.
+init_per_testcase(_, Config) ->
+    Config.
+
+%% Runs after the test case. Runs in the same process.
+end_per_testcase(_CaseName, Config) ->
+    meck:unload(),
+    Config.
+
+%%%%%%%%%%%%%
+%%% TESTS %%%
+%%%%%%%%%%%%%
+
+master_config(_Config) ->
+    FirehoseChannelId = 21894100,
+    ChannelId = 21894200,
+
+    logplex_firehose:create_ets_tables(),
+    logplex_firehose:enable(),
+
+    undefined = logplex_firehose:next_shard(ChannelId, <<"app">>),
+    undefined = logplex_firehose:next_shard(ChannelId, <<"filtered">>),
+
+    application:set_env(logplex, firehose_channel_ids, lists:concat([FirehoseChannelId])),
+    application:set_env(logplex, firehose_filter_tokens, "filtered"),
+    logplex_firehose:enable(),
+
+    undefined = logplex_firehose:next_shard(ChannelId, <<"app">>),
+    undefined = logplex_firehose:next_shard(ChannelId, <<"app">>),
+    FirehoseChannelId = logplex_firehose:next_shard(ChannelId, <<"filtered">>),
+    FirehoseChannelId = logplex_firehose:next_shard(ChannelId, <<"filtered">>),
+
+    logplex_firehose:disable(),
+    undefined = logplex_firehose:next_shard(ChannelId, <<"app">>),
+    undefined = logplex_firehose:next_shard(ChannelId, <<"filtered">>),
+    ok.
+
+post_msg(_Config) ->
+    FirehoseChannelId = 21894100,
+    ChannelId = 21894200,
+    Msg1 = term_to_binary(make_ref()),
+    Msg2 = term_to_binary(make_ref()),
+    Msg3 = term_to_binary(make_ref()),
+
+    meck:expect(logplex_channel, post_msg, [{[{channel, '_'}, '_'], ok}]),
+
+    ok = logplex_firehose:post_msg(ChannelId, <<"app">>, Msg1),
+    false = meck:called(logplex_channel, post_msg, [{channel, FirehoseChannelId}, Msg1]),
+
+    ok = logplex_firehose:post_msg(ChannelId, <<"heroku">>, Msg1),
+    false = meck:called(logplex_channel, post_msg, [{channel, FirehoseChannelId}, Msg1]),
+
+    application:set_env(logplex, firehose_channel_ids, lists:concat([FirehoseChannelId])),
+    application:set_env(logplex, firehose_filter_tokens, "heroku"),
+    logplex_firehose:create_ets_tables(),
+    logplex_firehose:enable(),
+
+    ok = logplex_firehose:post_msg(ChannelId, <<"heroku">>, Msg1),
+    true = meck:called(logplex_channel, post_msg, [{channel, FirehoseChannelId}, Msg1]),
+    
+    ok = logplex_firehose:post_msg(ChannelId, <<"app">>, Msg2),
+    false = meck:called(logplex_channel, post_msg, [{channel, FirehoseChannelId}, Msg2]),
+
+    ok = logplex_firehose:post_msg(FirehoseChannelId, <<"heroku">>, Msg3),
+    false = meck:called(logplex_channel, post_msg, [{channel, FirehoseChannelId}, Msg3]),
+    
+    ok.
+
+distribution(_Config) ->
+    FirehoseChannelId = "21894100,21894101",
+    ChannelId = 21894200,
+
+    meck:expect(logplex_channel, post_msg, [{[{channel, '_'}, '_'], ok}]),
+
+    application:set_env(logplex, firehose_channel_ids, FirehoseChannelId),
+    application:set_env(logplex, firehose_filter_tokens, "heroku"),
+    logplex_firehose:create_ets_tables(),
+    logplex_firehose:enable(),
+
+    [ send_messages(1000, ChannelId, <<"heroku">>) || _Id <- lists:seq(1, 100) ],
+
+    meck:wait(1000*100, logplex_channel, post_msg, [{channel, '_'}, '_'], 15000),
+    Calls1 = meck:num_calls(logplex_channel, post_msg, [{channel,21894100}, '_']),
+    Calls2 = meck:num_calls(logplex_channel, post_msg, [{channel,21894101}, '_']),
+    ct:pal("~p, ~p", [Calls1, Calls2]),
+
+    % assert random distribution with 0.5% accuracy
+    true = calls_within(Calls1, 1000*50, 0.005),
+    true = calls_within(Calls2, 1000*50, 0.005),
+    ok.
+
+%%%--------------------------------------------------------------------
+%%% private functions
+%%%--------------------------------------------------------------------
+
+calls_within(Amount, Target, Variance) when is_float(Variance) ->
+    Delta = Target * Variance,
+    calls_within(Amount, Target, round(Delta));
+
+calls_within(Amount, Target, Delta)
+  when is_integer(Delta),
+       Amount =< Target + Delta,
+       Amount >= Target - Delta ->
+    true;
+calls_within(_, _, _) ->
+    false.
+
+send_messages(Amount, Where, Token) ->
+    spawn_link(fun () ->
+                       send_messages_(Amount, Where, Token)
+               end).
+
+send_messages_(0, _Where, _Token) ->
+    done;
+send_messages_(Amount, Where, Token) ->
+    ok = logplex_firehose:post_msg(Where, Token, make_message()),
+    send_messages(Amount -1, Where, Token).
+
+make_message() ->
+    term_to_binary(make_ref()).

--- a/upgrades/v72.1_v73/live_upgrade.erl
+++ b/upgrades/v72.1_v73/live_upgrade.erl
@@ -1,0 +1,145 @@
+f(UpgradeNode).
+UpgradeNode = fun () ->
+    CurVsn = "v72",
+    NextVsn = "v73",
+    case logplex_app:config(git_branch) of
+        CurVsn ->
+            io:format(whereis(user), "at=upgrade_start cur_vsn=~p~n", [tl(CurVsn)]);
+        NextVsn ->
+            io:format(whereis(user),
+                      "at=upgrade type=retry cur_vsn=~p old_vsn=~p~n", [tl(CurVsn), tl(NextVsn)]);
+        Else ->
+            io:format(whereis(user),
+                      "at=upgrade_start old_vsn=~p abort=wrong_version", [tl(Else)]),
+            erlang:error({wrong_version, Else})
+    end,
+
+    %% Stateless
+    {module, logplex_app} = l(logplex_app),
+    {module, logplex_db} = l(logplex_db),
+    {module, logplex_firehose} = l(logplex_firehose),
+    {module, logplex_message} = l(logplex_message),
+    {module, logplex_stats} = l(logplex_stats),
+    {module, logplex_worker} = l(logplex_worker),
+    {module, nsync_callback} = l(nsync_callback),
+
+    application:set_env(logplex, firehose_channel_ids, "26281516,26718104,26718116"),
+
+    Self = self(),
+    spawn_link(fun () ->
+        Owner = whereis(logplex_db),
+        [ ets:give_away(Tab, Owner, undefined) ||
+          Tab <- logplex_firehose:create_ets_tables() ],
+        Self ! ets_done
+    end),
+
+    receive
+        ets_done ->
+            logplex_firehose:read_and_store_master_info()
+    end,
+
+    io:format(whereis(user), "at=upgrade_end cur_vsn=~p~n", [NextVsn]),
+    ok = application:set_env(logplex, git_branch, NextVsn),
+    ok
+end.
+
+f(DowngradeNode).
+DowngradeNode = fun () ->
+    CurVsn = "v73",
+    NextVsn = "v72",
+    case logplex_app:config(git_branch) of
+        CurVsn ->
+            io:format(whereis(user), "at=upgrade_start cur_vsn=~p~n", [tl(CurVsn)]);
+        NextVsn ->
+            io:format(whereis(user),
+                      "at=upgrade type=retry cur_vsn=~p old_vsn=~p~n", [tl(CurVsn), tl(NextVsn)]);
+        Else ->
+            io:format(whereis(user),
+                      "at=upgrade_start old_vsn=~p abort=wrong_version", [tl(Else)]),
+            erlang:error({wrong_version, Else})
+    end,
+
+    %% Stateless
+
+    {module, logplex_app} = l(logplex_app),
+    {module, logplex_db} = l(logplex_db),
+    {module, logplex_message} = l(logplex_message),
+    {module, logplex_stats} = l(logplex_stats),
+    {module, logplex_worker} = l(logplex_worker),
+    {module, nsync_callback} = l(nsync_callback),
+
+    application:unset_env(logplex, firehose_channel_ids),
+
+    ets:delete(firehose_workers),
+    ets:delete(firehose_master),
+
+    io:format(whereis(user), "at=upgrade_end cur_vsn=~p~n", [NextVsn]),
+    ok = application:set_env(logplex, git_branch, NextVsn),
+    ok
+end.
+
+f(NodeVersions).
+NodeVersions = fun () ->
+    lists:keysort(3,
+                  [{N,
+                    element(2, rpc:call(N, application, get_env, [logplex, git_branch])),
+                    rpc:call(N, os, getenv, ["INSTANCE_NAME"])}
+                   || N <- [node() | nodes()] ])
+end.
+
+f(NodesAt).
+NodesAt = fun (Vsn) ->
+    [ N || {N, V, _} <- NodeVersions(), V =:= Vsn ]
+end.
+
+f(RollingDowngrade).
+RollingDowngrade = fun (Nodes) ->
+  lists:foldl(fun (N, {good, Downgraded}) ->
+    case rpc:call(N, erlang, apply, [ DowngradeNode, [] ]) of
+      ok ->
+        {good, [N | Downgraded]};
+      Else ->
+        {{bad, N, Else}, Downgraded}
+    end;
+    (N, {_, _} = Acc) -> Acc
+    end,
+    {good, []},
+    Nodes)
+end.
+
+f(RollingUpgrade).
+RollingUpgrade = fun (Nodes) ->
+  lists:foldl(fun (N, {good, Upgraded}) ->
+    case rpc:call(N, erlang, apply, [ UpgradeNode, [] ]) of
+      ok ->
+        {good, [N | Upgraded]};
+      Else ->
+        {{bad, N, Else}, Upgraded}
+    end;
+    (N, {_, _} = Acc) -> Acc
+    end,
+    {good, []},
+    Nodes)
+end.
+
+f(Deactivate).
+Deactivate = fun () ->
+    application:unset_env(logplex, firehose_channel_ids),
+    logplex_firehose:read_and_store_master_info(),
+    ok
+end.
+
+f(RollingDeactivate).
+RollingDeactivate = fun (Nodes) ->
+  lists:foldl(fun (N, {good, Deactivated}) ->
+    case rpc:call(N, erlang, apply, [ Deactivate, [] ]) of
+      ok ->
+        {good, [N | Deactivated]};
+      Else ->
+        {{bad, N, Else}, Deactivated}
+    end;
+    (N, {_, _} = Acc) -> Acc
+    end,
+    {good, []},
+    Nodes)
+end.


### PR DESCRIPTION
The firehose will syphon off select messages and submit those messages
to a pool of available firehose channels. This allows for subset of logs
to be redirected down a known smaller group of channels.

The firehose is controlled via two environment variables
`FIREHOSE_CHANNEL_IDS` and `FIREHOSE_FILTER_TOKENS`. Both are comma
separated lists. The former is a list the list of channels the firehose
will use. The latter is a list of interested app token names that should
be filtered down the firehose.

```
FIREHOSE_CHANNEL_IDS="1000,1100,1200"
FIREHOSE_FILTER_TOKENS="events,metrics"
```

The above variables would filter all "events" and "metrics" log messages
down the firehose. The firehose itself will shard logs across three
channels, 1000, 1100, and 1200 using random distribution.

The firehose can be disabled at runtime by simply calling

``` erlang
logplex_firehose:disable().
```

Once disabled the firehose can be enabled again by using

``` erlang
logplex_firehose:enable().
```

This allows for dynamic reconfiguration of the firehose by modifing the
logplex application env variables at runtime. Those variables are
lowercase versions of the OS environment variables
`firehose_channel_ids` and `firehose_filter_tokens` respectively.
