### PR TITLE
Fix an incorrect RFC number.

### DIFF
--- a/doc/README.http_drains.md
+++ b/doc/README.http_drains.md
@@ -43,6 +43,6 @@ The body of a request from a Logplex HTTP drain is a series of [RFC5424](https:/
 
 So a request body for `application/logplex-1` should be as follows:
 
-    <NumberOfBytes/ASCII encoded integer><Space character><RFC5452 message:NumberOfBytes long>
+    <NumberOfBytes/ASCII encoded integer><Space character><RFC5424 message:NumberOfBytes long>
 
 repeated `logplex-msg-count` times.


### PR DESCRIPTION
doc/README.http_drains.md refers incorrect RFC number. The RFC for syslog is 5424, not 5452.
