### PR TITLE
Preserve query string in logs_rest API redirects.

### DIFF
--- a/src/logplex_logs_rest.erl
+++ b/src/logplex_logs_rest.erl
@@ -58,9 +58,12 @@ init(_Transport, Req0, [api]) ->
                          cowboy_req:reply(404, [], "", Req0);
                      Endpoint ->
                         {Path, Req1} = cowboy_req:path(Req0),
+                        {Query, Req2} = cowboy_req:qs(Req1),
+                        ?INFO("at=api_redirect path=~p query=~p", [Path, Query]),
                         cowboy_req:reply(302,
-                                         [{<<"Location">>, [Endpoint, Path]}],
-                                         "redirecting", Req1)
+                                         [{<<"Location">>, [Endpoint, Path,
+                                                            "?", Query]}],
+                                         "redirecting", Req2)
                  end,
     {shutdown, Req, no_state};
 init(_Transport, _Req, [logs]) ->


### PR DESCRIPTION
Found out we were dropping query parameters on the redirect here.
