### PR TITLE
treat 429 status codes properly

### DIFF
--- a/src/logplex_http_drain.erl
+++ b/src/logplex_http_drain.erl
@@ -341,7 +341,6 @@ try_send(Frame = #frame{tries = Tries},
                 success ->
                     ready_to_send(sent_frame(Frame, State));
                 temp_fail ->
-                    logplex_http_client:close(Pid),
                     http_fail(retry_frame(Frame, State));
                 perm_fail ->
                     ready_to_send(drop_frame(Frame, State))
@@ -379,6 +378,7 @@ try_send(Frame = #frame{tries = 0, msg_count=C}, State = #state{}) ->
 %% errors) are perm failures, so drop the frame and anything else is a
 %% temp failure, so retry the frame.
 status_action(N) when 200 =< N, N < 300 -> success;
+status_action(429) -> temp_fail;
 status_action(N) when 400 =< N, N < 500 -> perm_fail;
 status_action(_) -> temp_fail.
 


### PR DESCRIPTION
According to [RFC6585](http://tools.ietf.org/html/rfc6585#section-4)
this status code is used to indicate rate limiting has occurred and that
the request should be retried.

Furthermore, the `http_fail` method (L295) handles closing out the socket in a
safer manner, so I have removed the extra call.