### PR TITLE
Drain performance

### DIFF
--- a/src/logplex.app.src
+++ b/src/logplex.app.src
@@ -38,7 +38,7 @@
     ,{http_frame_retries, 1} % #extra attempts after first
     ,{http_log_input_port, 8601} % syslog/http tcp listen port
     ,{http_port, 8001}
-    ,{http_reconnect_time_s, 1} % seconds
+    ,{http_reconnect_time, 10} % ms
     ,{http_send_loss_msg, send} % send | dont_send
     ,{log_history, 1500}
     ,{log_unknown_tokens, false} % bool

--- a/src/logplex_http_drain.erl
+++ b/src/logplex_http_drain.erl
@@ -386,7 +386,7 @@ terminate(_Reason, _StateName, _State) ->
 code_change("v78", StateName,
             {state, DrainId, DrainTok, ChannelId, Uri, Buf, Client, OutQ,
              ReconnectTref, CloseTref, DropInfo, LastGoodTime, Service,
-             ConnectTime}=State0, undefined) ->
+             ConnectTime}, undefined) ->
     State = #state{drain_id=DrainId,
                    drain_tok=DrainTok,
                    channel_id=ChannelId,
@@ -401,14 +401,8 @@ code_change("v78", StateName,
                    last_good_time=LastGoodTime,
                    service=Service,
                    connect_time=ConnectTime},
-    ?INFO("drain_id=~p channel_id=~p dest=~s at=code_change "
-          "old_vsn=~p state_name=~p old_state=~p new_state=~p",
-          [DrainId, ChannelId, uri_to_string(Uri), "v78", StateName, State0, State]),
     {ok, StateName, State};
-code_change(OldVsn, StateName, State, Extra) ->
-    ?WARN("at=code_change unexpected=code_change"
-          "old_vsn=~p state_name=~p state=~p extra=~p",
-          [OldVsn, StateName, State, Extra]),
+code_change(_OldVsn, StateName, State, _Extra) ->
     {ok, StateName, State}.
 
 %% @private

--- a/src/logplex_http_drain.erl
+++ b/src/logplex_http_drain.erl
@@ -165,11 +165,11 @@ connected(timeout, S = #state{}) ->
 connected({timeout, TRef, ?CLOSE_TIMEOUT_MSG}, State=#state{close_tref=TRef}) ->
     case close_if_idle(State) of
         {closed, ClosedState} ->
-            {next_state, disconnected, ClosedState, hibernate};
+            {next_state, disconnected, ClosedState, ?HIBERNATE_TIMEOUT};
         {not_closed, State} ->
             case close_if_old(State) of
                 {closed, ClosedState} ->
-                    {next_state, disconnected, ClosedState, hibernate};
+                    {next_state, disconnected, ClosedState, ?HIBERNATE_TIMEOUT};
                 {not_closed, ContinueState} ->
                     {next_state, connected, ContinueState}
             end
@@ -295,12 +295,12 @@ try_connect(State = #state{uri=Uri,
 http_fail(State = #state{client=Client}) ->
     %% Close any existing client connection.
     ClosedState = case Client of
-                   Pid when is_pid(Pid) ->
-                       logplex_http_client:close(Pid),
-                       State#state{client = undefined};
-                   undefined ->
-                       State
-               end,
+                      Pid when is_pid(Pid) ->
+                          logplex_http_client:close(Pid),
+                          State#state{client = undefined};
+                      undefined ->
+                          State
+                  end,
     NewState = maybe_shrink(ClosedState),
     %% We hibernate only when we need to reconnect with a timer. The timer
     %% acts as a rate limiter! If you remove the timer, you must re-think

--- a/src/logplex_http_drain.erl
+++ b/src/logplex_http_drain.erl
@@ -388,7 +388,7 @@ terminate(_Reason, _StateName, _State) ->
 %% @private
 code_change("v78", StateName,
             {state, DrainId, DrainTok, ChannelId, Uri, Buf, Client, OutQ,
-             ReconnectTref, CloseTref, DropInfo, LastGoodTime, Service,
+             ReconnectTref, CloseTref, DropInfo, _LastGoodTime, Service,
              ConnectTime}, undefined) ->
     State = #state{drain_id=DrainId,
                    drain_tok=DrainTok,
@@ -401,7 +401,7 @@ code_change("v78", StateName,
                    reconnect_attempt=0,
                    close_tref=CloseTref,
                    drop_info=DropInfo,
-                   last_good_time=LastGoodTime,
+                   last_good_time=never,
                    service=Service,
                    connect_time=ConnectTime},
     {ok, StateName, State};

--- a/src/logplex_http_drain.erl
+++ b/src/logplex_http_drain.erl
@@ -383,6 +383,24 @@ terminate(_Reason, _StateName, _State) ->
     ok.
 
 %% @private
+code_change("v78", StateName,
+            {DrainId, DrainTok, ChannelId, Uri, Buf, Client, OutQ,
+             ReconnectTref, CloseTref, DropInfo, LastGoodTime, Service,
+             ConnectTime} , undefined) ->
+    {ok, StateName, #state{drain_id=DrainId,
+                           drain_tok=DrainTok,
+                           channel_id=ChannelId,
+                           uri=Uri,
+                           buf=Buf,
+                           client=Client,
+                           out_q=OutQ,
+                           reconnect_tref=ReconnectTref,
+                           reconnect_attempt=0,
+                           close_tref=CloseTref,
+                           drop_info=DropInfo,
+                           last_good_time=LastGoodTime,
+                           service=Service,
+                           connect_time=ConnectTime}, ?HIBERNATE_TIMEOUT};
 code_change(_OldVsn, StateName, State, _Extra) ->
     {ok, StateName, State, ?HIBERNATE_TIMEOUT}.
 

--- a/src/logplex_http_drain.erl
+++ b/src/logplex_http_drain.erl
@@ -280,7 +280,7 @@ try_connect(State = #state{uri=Uri,
                   "attempt=success connect_time=~p",
                   log_info(State, [ltcy(ConnectStart, ConnectEnd)])),
             NewTimerState = start_close_timer(State),
-            ready_to_send(NewTimerState#state{client=Pid, service=normal,
+            ready_to_send(NewTimerState#state{client=Pid,
                                               connect_time=ConnectEnd,
                                               reconnect_attempt=0});
         Why ->
@@ -473,7 +473,7 @@ sent_frame(#frame{msg_count=Count, loss_count=Lost}, State0=#state{drop_info=Dro
                                                                    buf=Buf,
                                                                    service=Status}) ->
     maybe_resize(Status, Buf),
-    State = State0#state{last_good_time=os:timestamp()},
+    State = State0#state{last_good_time=os:timestamp(), service=normal},
 
     msg_stat(drain_delivered, Count, State),
     logplex_realtime:incr('drain.delivered', Count),

--- a/src/logplex_http_drain.erl
+++ b/src/logplex_http_drain.erl
@@ -384,25 +384,32 @@ terminate(_Reason, _StateName, _State) ->
 
 %% @private
 code_change("v78", StateName,
-            {DrainId, DrainTok, ChannelId, Uri, Buf, Client, OutQ,
+            {state, DrainId, DrainTok, ChannelId, Uri, Buf, Client, OutQ,
              ReconnectTref, CloseTref, DropInfo, LastGoodTime, Service,
-             ConnectTime} , undefined) ->
-    {ok, StateName, #state{drain_id=DrainId,
-                           drain_tok=DrainTok,
-                           channel_id=ChannelId,
-                           uri=Uri,
-                           buf=Buf,
-                           client=Client,
-                           out_q=OutQ,
-                           reconnect_tref=ReconnectTref,
-                           reconnect_attempt=0,
-                           close_tref=CloseTref,
-                           drop_info=DropInfo,
-                           last_good_time=LastGoodTime,
-                           service=Service,
-                           connect_time=ConnectTime}, ?HIBERNATE_TIMEOUT};
-code_change(_OldVsn, StateName, State, _Extra) ->
-    {ok, StateName, State, ?HIBERNATE_TIMEOUT}.
+             ConnectTime}=State0, undefined) ->
+    State = #state{drain_id=DrainId,
+                   drain_tok=DrainTok,
+                   channel_id=ChannelId,
+                   uri=Uri,
+                   buf=Buf,
+                   client=Client,
+                   out_q=OutQ,
+                   reconnect_tref=ReconnectTref,
+                   reconnect_attempt=0,
+                   close_tref=CloseTref,
+                   drop_info=DropInfo,
+                   last_good_time=LastGoodTime,
+                   service=Service,
+                   connect_time=ConnectTime},
+    ?INFO("drain_id=~p channel_id=~p dest=~s at=code_change "
+          "old_vsn=~p state_name=~p old_state=~p new_state=~p",
+          [DrainId, ChannelId, uri_to_string(Uri), "v78", StateName, State0, State]),
+    {ok, StateName, State};
+code_change(OldVsn, StateName, State, Extra) ->
+    ?WARN("at=code_change unexpected=code_change"
+          "old_vsn=~p state_name=~p state=~p extra=~p",
+          [OldVsn, StateName, State, Extra]),
+    {ok, StateName, State}.
 
 %% @private
 log_info(#state{drain_id=DrainId, channel_id=ChannelId, uri=URI}, Rest)

--- a/src/logplex_utils.erl
+++ b/src/logplex_utils.erl
@@ -23,7 +23,7 @@
 -module(logplex_utils).
 -export([rpc/4, set_weight/1, resolve_host/1,
          parse_msg/1, filter/2, formatted_utc_date/0, format/1, field_val/2, field_val/3,
-         format/4,
+         format/4, format_utc_timestamp/0, format_utc_timestamp/1,
          parse_redis_url/1, nl/1, to_int/1]).
 
 -include("logplex.hrl").
@@ -71,6 +71,15 @@ filter(Msg, [Fun|Tail]) ->
         true -> filter(Msg, Tail);
         _ -> false
     end.
+
+format_utc_timestamp() ->
+    format_utc_timestamp(os:timestamp()).
+
+format_utc_timestamp({_, _, Micro}=TS) ->
+    {{Year, Month, Day}, {Hour, Minute, Second}} = calendar:now_to_universal_time(TS),
+    % 2012-04-23T18:25:43.511Z
+    io_lib:format("~w-~2..0w-~2..0wT~2..0w:~2..0w:~2..0w.~6..0wZ",
+                  [Year, Month, Day, Hour, Minute, Second, Micro]).
 
 formatted_utc_date() ->
     {{Year,Month,Day},{Hour,Min,Sec}} = Local = erlang:localtime(),

--- a/upgrades/v78_v79/live_upgrade.erl
+++ b/upgrades/v78_v79/live_upgrade.erl
@@ -24,7 +24,7 @@ UpgradeNode = fun () ->
     l(logplex_http_drain),
 
     % perform the state change via code_change
-    [ ok = sys:change_code(Pid, logplex_http_drain, OldVsn, undefined, 60000) || Pid <- Drins, erlang:is_process_alive(Pid) ],
+    [ ok = sys:change_code(Pid, logplex_http_drain, OldVsn, undefined, 60000) || Pid <- Drains, erlang:is_process_alive(Pid) ],
 
     % resume operation of all the http drains
     [ ok = sys:resume(Pid, 60000) || Pid <- Drains, erlang:is_process_alive(Pid) ],

--- a/upgrades/v78_v79/live_upgrade.erl
+++ b/upgrades/v78_v79/live_upgrade.erl
@@ -18,16 +18,16 @@ UpgradeNode = fun () ->
     Drains = [ Pid || {Pid, http} <- gproc:lookup_local_properties(drain_type)],
 
     % suspend all the http drains in preparation for a code change
-    [ sys:suspend(Pid, 30000) || Pid <- Drains ],
+    [ ok = sys:suspend(Pid, 30000) || Pid <- Drains ],
 
     % load the new version of the module
     l(logplex_http_drain),
 
     % perform the state change via code_change
-    [ sys:change_code(Pid, logplex_http_drain, OldVsn, undefined, 30000) || Pid <- Drains],
+    [ ok = sys:change_code(Pid, logplex_http_drain, OldVsn, undefined, 30000) || Pid <- Drains],
 
     % resume operation of all the http drains
-    [ sys:resume(Pid, 30000) || Pid <- Drains ],
+    [ ok = sys:resume(Pid, 30000) || Pid <- Drains ],
 
     io:format(whereis(user), "at=upgrade_end cur_vsn=~p~n", [NextVsn]),
     ok = application:set_env(logplex, git_branch, NextVsn),

--- a/upgrades/v78_v79/live_upgrade.erl
+++ b/upgrades/v78_v79/live_upgrade.erl
@@ -1,0 +1,67 @@
+f(UpgradeNode).
+UpgradeNode = fun () ->
+    OldVsn = "v78",
+    NextVsn = "v79",
+    case logplex_app:config(git_branch) of
+        OldVsn ->
+            io:format(whereis(user), "at=upgrade_start cur_vsn=~p~n", [tl(OldVsn)]);
+        NextVsn ->
+            io:format(whereis(user),
+                      "at=upgrade type=retry cur_vsn=~p old_vsn=~p~n", [tl(OldVsn), tl(NextVsn)]);
+        Else ->
+            io:format(whereis(user),
+                      "at=upgrade_start old_vsn=~p abort=wrong_version", [tl(Else)]),
+            erlang:error({wrong_version, Else})
+    end,
+
+    % lookup all the HTTP drain pids
+    Drains = [ Pid || {Pid, http} <- gproc:lookup_local_properties(drain_type)],
+
+    % suspend all the http drains in preparation for a code change
+    [ sys:suspend(Pid, 30000) || Pid <- Drains ],
+
+    % load the new version of the module
+    l(logplex_http_drain),
+
+    % perform the state change via code_change
+    [ sys:change_code(Pid, logplex_http_drain, OldVsn, undefined, 30000) || Pid <- Drains],
+
+    % resume operation of all the http drains
+    [ sys:resume(Pid, 30000) || Pid <- Drains ],
+
+    io:format(whereis(user), "at=upgrade_end cur_vsn=~p~n", [NextVsn]),
+    ok = application:set_env(logplex, git_branch, NextVsn),
+    ok
+end.
+
+f(NodeVersions).
+NodeVersions = fun () ->
+    lists:keysort(3,
+                  [{N,
+                    element(2, rpc:call(N, application, get_env, [logplex, git_branch])),
+                    rpc:call(N, os, getenv, ["INSTANCE_NAME"])}
+                   || N <- [node() | nodes()] ])
+end.
+
+f(NodesAt).
+NodesAt = fun (Vsn) ->
+    [ N || {N, V, _} <- NodeVersions(), V =:= Vsn ]
+end.
+
+f(NextNodesAt).
+NextNodesAt = fun(Vsn, N) -> lists:sublist(NodesAt(Vsn), N) end.
+
+f(RollingUpgrade).
+RollingUpgrade = fun (Nodes) ->
+  lists:foldl(fun (N, {good, Upgraded}) ->
+    case rpc:call(N, erlang, apply, [ UpgradeNode, [] ]) of
+      ok ->
+        {good, [N | Upgraded]};
+      Else ->
+        {{bad, N, Else}, Upgraded}
+    end;
+    (N, {_, _} = Acc) -> Acc
+    end,
+    {good, []},
+    Nodes)
+end.

--- a/upgrades/v78_v79/live_upgrade.erl
+++ b/upgrades/v78_v79/live_upgrade.erl
@@ -18,16 +18,16 @@ UpgradeNode = fun () ->
     Drains = [ Pid || {Pid, http} <- gproc:lookup_local_properties(drain_type)],
 
     % suspend all the http drains in preparation for a code change
-    [ ok = sys:suspend(Pid, 30000) || Pid <- Drains ],
+    [ ok = sys:suspend(Pid, 60000) || Pid <- Drains, erlang:is_process_alive(Pid) ],
 
     % load the new version of the module
     l(logplex_http_drain),
 
     % perform the state change via code_change
-    [ ok = sys:change_code(Pid, logplex_http_drain, OldVsn, undefined, 30000) || Pid <- Drains],
+    [ ok = sys:change_code(Pid, logplex_http_drain, OldVsn, undefined, 60000) || Pid <- Drins, erlang:is_process_alive(Pid) ],
 
     % resume operation of all the http drains
-    [ ok = sys:resume(Pid, 30000) || Pid <- Drains ],
+    [ ok = sys:resume(Pid, 60000) || Pid <- Drains, erlang:is_process_alive(Pid) ],
 
     io:format(whereis(user), "at=upgrade_end cur_vsn=~p~n", [NextVsn]),
     ok = application:set_env(logplex, git_branch, NextVsn),


### PR DESCRIPTION
When a drain is disconnected it currently takes at least 1 full seconds before the connection is re-established. For a high volume drain, this will almost guarantee log loss as the short buffer will be rapidly filled up. This branch attempts to resolve that behaviour by removing the forced hibernate and implementing an exponential backoff on re-connect behaviour.