### PR TITLE
Fix crash when ps/source filtering.

### DIFF
--- a/src/logplex_api.erl
+++ b/src/logplex_api.erl
@@ -634,9 +634,9 @@ filters([{<<"ps">>, Ps}|Tail], Filters) ->
     Size = byte_size(Ps),
     Filters1 = [
         fun(Msg) ->
-            case Msg#msg.ps of
-                Ps -> true;
-                <<Ps:Size/binary, ".", _/binary>> -> true;
+            case Msg of
+                #msg{ps=Ps} -> true;
+                #msg{ps = <<Ps:Size/binary, ".", _/binary>>} -> true;
                 _ -> false
             end
         end | Filters],
@@ -645,7 +645,10 @@ filters([{<<"ps">>, Ps}|Tail], Filters) ->
 filters([{<<"source">>, Source}|Tail], Filters) ->
     Filters1 = [
         fun(Msg) ->
-            Msg#msg.source == Source
+            case Msg of
+                #msg{source=Source} -> true;
+                _ -> false
+            end
         end | Filters],
     filters(Tail, Filters1);
 


### PR DESCRIPTION
We can't assume Msg here is going to be a msg record since
`logplex_utils:parse_msg` can sometimes return undefined for log lines
that don't match our pattern. Need to pull apart the record format
inside the match so we can fall down to the catch-all.

This should see the 500s we're sometimes seeing with filtered
tails. (the --ps or --source argument)
