### PR TITLE
Revert https hibernate changes

### DIFF
--- a/src/logplex_http_drain.erl
+++ b/src/logplex_http_drain.erl
@@ -168,11 +168,11 @@ connected(timeout, S = #state{}) ->
 connected({timeout, TRef, ?CLOSE_TIMEOUT_MSG}, State=#state{close_tref=TRef}) ->
     case close_if_idle(State) of
         {closed, ClosedState} ->
-            {next_state, disconnected, ClosedState, ?HIBERNATE_TIMEOUT};
+            {next_state, disconnected, ClosedState, hibernate};
         {not_closed, State} ->
             case close_if_old(State) of
                 {closed, ClosedState} ->
-                    {next_state, disconnected, ClosedState, ?HIBERNATE_TIMEOUT};
+                    {next_state, disconnected, ClosedState, hibernate};
                 {not_closed, ContinueState} ->
                     {next_state, connected, ContinueState}
             end

--- a/upgrades/v79_v80/live_upgrade.erl
+++ b/upgrades/v79_v80/live_upgrade.erl
@@ -1,0 +1,55 @@
+f(UpgradeNode).
+UpgradeNode = fun () ->
+    OldVsn = "v79",
+    NextVsn = "v80",
+    case logplex_app:config(git_branch) of
+        OldVsn ->
+            io:format(whereis(user), "at=upgrade_start cur_vsn=~p~n", [tl(OldVsn)]);
+        NextVsn ->
+            io:format(whereis(user),
+                      "at=upgrade type=retry cur_vsn=~p old_vsn=~p~n", [tl(OldVsn), tl(NextVsn)]);
+        Else ->
+            io:format(whereis(user),
+                      "at=upgrade_start old_vsn=~p abort=wrong_version", [tl(Else)]),
+            erlang:error({wrong_version, Else})
+    end,
+
+    % load the new version of the module
+    l(logplex_http_drain),
+
+    io:format(whereis(user), "at=upgrade_end cur_vsn=~p~n", [NextVsn]),
+    ok = application:set_env(logplex, git_branch, NextVsn),
+    ok
+end.
+
+f(NodeVersions).
+NodeVersions = fun () ->
+    lists:keysort(3,
+                  [{N,
+                    element(2, rpc:call(N, application, get_env, [logplex, git_branch])),
+                    rpc:call(N, os, getenv, ["INSTANCE_NAME"])}
+                   || N <- [node() | nodes()] ])
+end.
+
+f(NodesAt).
+NodesAt = fun (Vsn) ->
+    [ N || {N, V, _} <- NodeVersions(), V =:= Vsn ]
+end.
+
+f(NextNodesAt).
+NextNodesAt = fun(Vsn, N) -> lists:sublist(NodesAt(Vsn), N) end.
+
+f(RollingUpgrade).
+RollingUpgrade = fun (Nodes) ->
+  lists:foldl(fun (N, {good, Upgraded}) ->
+    case rpc:call(N, erlang, apply, [ UpgradeNode, [] ]) of
+      ok ->
+        {good, [N | Upgraded]};
+      Else ->
+        {{bad, N, Else}, Upgraded}
+    end;
+    (N, {_, _} = Acc) -> Acc
+    end,
+    {good, []},
+    Nodes)
+end.


### PR DESCRIPTION
Monitoring of the logplex cluster revealed that post this change set the
binary memory usage climbed. IMO this doesn't make sense because the
drain buffer process will still retain references to any binaries
cleaned up by forcing a hibernate here. But, graphs do not lie. This
commit reverts the changes in an attempt to reclaim that binary memory.

For reference this original commit that converted these
b551562