### PR TITLE
Tail session fixes

### DIFF
--- a/src/logplex_api.erl
+++ b/src/logplex_api.erl
@@ -706,7 +706,7 @@ json_error(Code, Err) ->
 api_relative_url(canary, UUID) when is_binary(UUID) ->
     iolist_to_binary([<<"/v2/canary-fetch/">>, UUID]);
 api_relative_url(_APIVSN, UUID) when is_binary(UUID) ->
-    iolist_to_binary([<<"/sessions/">>, UUID]).
+    iolist_to_binary([logplex_app:config(api_endpoint_url, ""), <<"/sessions/">>, UUID]).
 
 end_chunked_response(Socket) ->
     gen_tcp:close(Socket),

--- a/src/logplex_api.erl
+++ b/src/logplex_api.erl
@@ -224,7 +224,8 @@ handlers() ->
         Body = Req:recv_body(),
         UUID = logplex_session:publish(Body),
         not is_binary(UUID) andalso exit({expected_binary, UUID}),
-        {201, api_relative_url(api_v1, UUID)}
+        {201, iolist_to_binary([logplex_app:config(api_endpoint_url, ""),
+                                <<"/sessions/">>, UUID, <<"?srv=srv">>])}
     end},
 
     %% V2

--- a/src/logplex_api.erl
+++ b/src/logplex_api.erl
@@ -543,23 +543,23 @@ error_resp(RespCode, Body) ->
     throw({RespCode, Body}).
 
 
-filter_and_send_logs(Socket, Logs, [], _Num) ->
-    [gen_tcp:send(Socket, logplex_utils:format(logplex_utils:parse_msg(Msg))) || Msg <- lists:reverse(Logs)];
+%% filter_and_send_logs(Socket, Logs, [], _Num) ->
+%%     [gen_tcp:send(Socket, logplex_utils:format(logplex_utils:parse_msg(Msg))) || Msg <- lists:reverse(Logs)];
+%%
+%% filter_and_send_logs(Socket, Logs, Filters, Num) ->
+%%     filter_and_send_logs(Socket, Logs, Filters, Num, []).
+%%
+%% filter_and_send_logs(Socket, Logs, _Filters, Num, Acc) when Logs == []; Num == 0 ->
+%%     gen_tcp:send(Socket, Acc);
 
-filter_and_send_logs(Socket, Logs, Filters, Num) ->
-    filter_and_send_logs(Socket, Logs, Filters, Num, []).
-
-filter_and_send_logs(Socket, Logs, _Filters, Num, Acc) when Logs == []; Num == 0 ->
-    gen_tcp:send(Socket, Acc);
-
-filter_and_send_logs(Socket, [Msg|Tail], Filters, Num, Acc) ->
-    Msg1 = logplex_utils:parse_msg(Msg),
-    case logplex_utils:filter(Msg1, Filters) of
-        true ->
-            filter_and_send_logs(Socket, Tail, Filters, Num-1, [logplex_utils:format(Msg1)|Acc]);
-        false ->
-            filter_and_send_logs(Socket, Tail, Filters, Num, Acc)
-    end.
+%% filter_and_send_logs(Socket, [Msg|Tail], Filters, Num, Acc) ->
+%%     Msg1 = logplex_utils:parse_msg(Msg),
+%%     case logplex_utils:filter(Msg1, Filters) of
+%%         true ->
+%%             filter_and_send_logs(Socket, Tail, Filters, Num-1, [logplex_utils:format(Msg1)|Acc]);
+%%         false ->
+%%             filter_and_send_logs(Socket, Tail, Filters, Num, Acc)
+%%     end.
 
 filter_and_send_chunked_logs(Resp, Logs, [], _Num) ->
     [Resp:write_chunk(logplex_utils:format(logplex_utils:parse_msg(Msg))) || Msg <- lists:reverse(Logs)];
@@ -712,9 +712,9 @@ api_relative_url(canary, UUID) when is_binary(UUID) ->
 api_relative_url(_APIVSN, UUID) when is_binary(UUID) ->
     iolist_to_binary([logplex_app:config(api_endpoint_url, ""), <<"/sessions/">>, UUID]).
 
-end_chunked_response(Socket) ->
-    gen_tcp:close(Socket),
-    ok.
+%% end_chunked_response(Socket) ->
+%%     gen_tcp:close(Socket),
+%%     ok.
 
 uri_to_binary(Uri) ->
     iolist_to_binary(ex_uri:encode(Uri)).

--- a/src/logplex_api.erl
+++ b/src/logplex_api.erl
@@ -225,7 +225,7 @@ handlers() ->
         UUID = logplex_session:publish(Body),
         not is_binary(UUID) andalso exit({expected_binary, UUID}),
         {201, iolist_to_binary([logplex_app:config(api_endpoint_url, ""),
-                                <<"/sessions/">>, UUID, <<"?srv=srv">>])}
+                                <<"/sessions/">>, UUID])}
     end},
 
     %% V2

--- a/src/logplex_api.erl
+++ b/src/logplex_api.erl
@@ -273,11 +273,12 @@ handlers() ->
         not is_list(Logs) andalso exit({expected_list, Logs}),
 
         Socket = Req:get(socket),
-        Header = case logplex_channel:lookup_flag(no_redis, ChannelId) of
+        Header0 = case logplex_channel:lookup_flag(no_redis, ChannelId) of
                      no_redis -> ?HDR ++ [{"X-Heroku-Warning",
                                            logplex_app:config(no_redis_warning)}];
                      _ -> ?HDR
                  end,
+        Header = Header0 ++ [{"Connection", "close"}],
         Resp = Req:respond({200, Header, chunked}),
 
         inet:setopts(Socket, [{nodelay, true}, {packet_size, 1024 * 1024}, {recbuf, 1024 * 1024}]),

--- a/upgrades/v80_v81/live_upgrade.erl
+++ b/upgrades/v80_v81/live_upgrade.erl
@@ -1,0 +1,55 @@
+f(UpgradeNode).
+UpgradeNode = fun () ->
+    OldVsn = "v80",
+    NextVsn = "v81",
+    case logplex_app:config(git_branch) of
+        OldVsn ->
+            io:format(whereis(user), "at=upgrade_start cur_vsn=~p~n", [tl(OldVsn)]);
+        NextVsn ->
+            io:format(whereis(user),
+                      "at=upgrade type=retry cur_vsn=~p old_vsn=~p~n", [tl(OldVsn), tl(NextVsn)]);
+        Else ->
+            io:format(whereis(user),
+                      "at=upgrade_start old_vsn=~p abort=wrong_version", [tl(Else)]),
+            erlang:error({wrong_version, Else})
+    end,
+
+    % load the new version of the module
+    l(logplex_api),
+
+    io:format(whereis(user), "at=upgrade_end cur_vsn=~p~n", [NextVsn]),
+    ok = application:set_env(logplex, git_branch, NextVsn),
+    ok
+end.
+
+f(NodeVersions).
+NodeVersions = fun () ->
+    lists:keysort(3,
+                  [{N,
+                    element(2, rpc:call(N, application, get_env, [logplex, git_branch])),
+                    rpc:call(N, os, getenv, ["INSTANCE_NAME"])}
+                   || N <- [node() | nodes()] ])
+end.
+
+f(NodesAt).
+NodesAt = fun (Vsn) ->
+    [ N || {N, V, _} <- NodeVersions(), V =:= Vsn ]
+end.
+
+f(NextNodesAt).
+NextNodesAt = fun(Vsn, N) -> lists:sublist(NodesAt(Vsn), N) end.
+
+f(RollingUpgrade).
+RollingUpgrade = fun (Nodes) ->
+  lists:foldl(fun (N, {good, Upgraded}) ->
+    case rpc:call(N, erlang, apply, [ UpgradeNode, [] ]) of
+      ok ->
+        {good, [N | Upgraded]};
+      Else ->
+        {{bad, N, Else}, Upgraded}
+    end;
+    (N, {_, _} = Acc) -> Acc
+    end,
+    {good, []},
+    Nodes)
+end.


### PR DESCRIPTION
This PR fixes a number of issues related to tail sessions.

Firstly, when a session is created and logplex is aware of the api endpoint url, it should return full urls instead of just a relative path.

Secondly, when shipping logs out to tail sessions through an ELB the ELB would interpret the HTTP reply as invalid HTTP and return a 502 - Bad Gateway. The log shipping has been updated to use a chunked HTTP reply instead of appending data directly to the socket. Thus fixing the ELBs issue with the HTTP reply and resolving the 502 error.