### PR TITLE
Remove old and unnecessary srv parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ create a log session
 
 fetch logs for session
 
-    $ curl http://local:password@localhost:8001/sessions/9d53bf70-7964-4429-a589-aaa4df86fead?srv=1
+    $ curl http://local:password@localhost:8001/sessions/9d53bf70-7964-4429-a589-aaa4df86fead
     2012-12-10T03:00:48Z+00:00 app[console.1]: test message 1
 
 # Supervision Tree

--- a/src/logplex_api.erl
+++ b/src/logplex_api.erl
@@ -249,8 +249,6 @@ handlers() ->
     end},
 
     {['GET', "^/sessions/([\\w-]+)$"], fun(Req, [Session], _) ->
-        proplists:get_value("srv", Req:parse_qs()) == undefined
-            andalso error_resp(400, <<"[Error]: Please update your Heroku client to the most recent version. If this error message persists then uninstall the Heroku client gem completely and re-install.\n">>),
         Timeout = timer:seconds(logplex_app:config(session_lookup_timeout_s,
                                                    5)),
         Body = logplex_session:poll(list_to_binary(Session),
@@ -311,8 +309,6 @@ handlers() ->
     end},
 
     {['GET', "^/v2/canary-fetch/([\\w-]+)$"], fun(Req, [Session], _) ->
-        proplists:get_value("srv", Req:parse_qs()) == undefined
-            andalso error_resp(400, <<"[Error]: Please update your Heroku client to the most recent version. If this error message persists then uninstall the Heroku client gem completely and re-install.\n">>),
         Timeout = timer:seconds(logplex_app:config(session_lookup_timeout_s,
                                                    5)),
         Body = logplex_session:poll(list_to_binary(Session),

--- a/test/logplex_api_SUITE.erl
+++ b/test/logplex_api_SUITE.erl
@@ -119,7 +119,7 @@ v2_canary_fetch(Config) ->
     {v2_canary_session, SavedConfig} = ?config(saved_config, Config),
     Session = proplists:get_value(canary_session, SavedConfig),
     Api = ?config(api, Config) ++ "/v2/canary-fetch/"
-        ++ binary_to_list(Session) ++ "?srv=ct",
+        ++ binary_to_list(Session),
     Res = get_(Api, []),
     Headers = proplists:get_value(headers, Res),
     "text/html" = proplists:get_value("content-type", Headers),
@@ -153,7 +153,7 @@ unavailable_v2_canary_session(Config) ->
 unavailable_v2_canary_fetch(Config) ->
     Session = proplists:get_value(canary_session, Config),
     Api = ?config(api, Config) ++ "/v2/canary-fetch/"
-        ++ binary_to_list(Session) ++ "?srv=ct",
+        ++ binary_to_list(Session),
     Res = get_(Api, []),
     503 = proplists:get_value(status_code, Res).
 


### PR DESCRIPTION
`POST /sessions` and `GET /sessions/{id}` currently require a `srv` query parameter which is a vestige of how logplex's load balancing setup used to work. Now it's just an extra hurdle for clients.