### PR TITLE
track unknown tokens in folsom metrics

### DIFF
--- a/src/logplex_logs_rest.erl
+++ b/src/logplex_logs_rest.erl
@@ -110,6 +110,7 @@ token_auth(State, Req2, TokenId) ->
     case logplex_token:lookup(TokenId) of
         undefined ->
             ?INFO("at=authorization err=unknown_token token=~p", [TokenId]),
+            logplex_realtime:incr(unknown_token),
             {{false, ?BASIC_AUTH}, Req2, State};
         Token ->
             Name = logplex_token:name(Token),

--- a/src/logplex_message.erl
+++ b/src/logplex_message.erl
@@ -29,7 +29,9 @@ process_msgs(Msgs) ->
     [ case parse_msg(RawMsg) of
           {ok, TokenId} ->
               case logplex_token:lookup(TokenId) of
-                  undefined -> {error, invalid_token};
+                  undefined ->
+                      logplex_realtime:incr(unknown_token),
+                      {error, invalid_token};
                   Token ->
                       ChannelId = logplex_token:channel_id(Token),
                       TokenName = logplex_token:name(Token),

--- a/src/logplex_worker.erl
+++ b/src/logplex_worker.erl
@@ -100,6 +100,7 @@ route(Token, State = #state{}, RawMsg)
                   end,
             K = #logplex_stat{module=?MODULE, key=Key},
             logplex_stats:incr(K),
+            logplex_realtime:incr(unknown_token),
             ok
     end.
 


### PR DESCRIPTION
Use a counter to track unknown tokens that appear in syslog and http
interfaces (including anychan).