### PR TITLE
record firehose posts into realtime metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ script:
   LOCAL_IP='127.0.0.1' LOGPLEX_COOKIE=123 ERL_LIBS=`pwd`/deps/:$ERL_LIBS ct_run -spec
   logplex.spec -pa ebin
 otp_release:
-  - 17.5
   - 17.4
   - R16B02
 notifications:

--- a/src/logplex_realtime.erl
+++ b/src/logplex_realtime.erl
@@ -22,7 +22,7 @@
 %% OTHER DEALINGS IN THE SOFTWARE.
 -module(logplex_realtime).
 
--export([incr/1, incr/2, setup_metrics/0]).
+-export([incr/1, incr/2, setup_metrics/0, create_counter_metric/1]).
 
 -include("logplex_logging.hrl").
 


### PR DESCRIPTION
Add additional metrics around firehose channel posts. The metrics are per firehose shard. This allows for historical tracking of firehose usage and potential monitoring around post/sec to the shards.