### PR TITLE
Nsync control rods

### DIFF
--- a/doc/schema/schema.json
+++ b/doc/schema/schema.json
@@ -1,5 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-04/hyper-schema",
+  "type": [
+    "object"
+  ],
   "definitions": {
     "channel": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
@@ -237,24 +240,32 @@
     "health": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "title": "Healthchecks",
+      "definitions": {
+        "status": {
+          "description": "API control rod status (normal, read_only)",
+          "example": "normal",
+          "type": [
+            "string"
+          ]
+        }
+      },
       "links": [
         {
           "description": "Performs a health check against the API.",
           "href": "/healthcheck",
           "method": "GET",
-          "type": [
-            "string"
-          ],
-          "rel": "empty",
-          "response_example": {
-            "head": "HTTP/1.1 200 OK\n",
-            "body": "OK\n"
-          },
-          "title": "Check"
+          "rel": "self",
+          "targetSchema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "status": {
+                "$ref": "#/definitions/health/definitions/status"
+              }
+            }
+          }
         }
-      ],
-      "type": [
-        "object"
       ]
     },
     "session": {
@@ -427,9 +438,6 @@
       "$ref": "#/definitions/token"
     }
   },
-  "type": [
-    "object"
-  ],
   "title": "Logplex",
   "description": "The log router",
   "id": "api-logplex",

--- a/doc/schema/schema.md
+++ b/doc/schema/schema.md
@@ -1,13 +1,17 @@
-## Channel
+## <a name="resource-channel"></a>Channel
+
 A channel is a log stream.
 
 ### Attributes
+
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
 | **drains** | *array* | drains under the channel | `[{"id"=>123456, "token"=>"d.01234567-89ab-cdef-0123-456789abcdef", "url"=>"https://example.org"}]` |
 | **channel_id** | *integer* | unique identifier of channel | `123456` |
 | **tokens** | *array* | tokens under the channel | `[{"token"=>"t.01234567-89ab-cdef-0123-456789abcdef", "name"=>"my-token"}]` |
+
 ### Channel Create
+
 Create a new channel.
 
 ```
@@ -15,18 +19,21 @@ POST /channels
 ```
 
 #### Required Parameters
+
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
 | **name** | *string* | a name for the channel | `"my-channel"` |
 
 
 #### Optional Parameters
+
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
 | **tokens** | *array* | names of tokens to create | `["my-token","your-token"]` |
 
 
 #### Curl Example
+
 ```bash
 $ curl -n -X POST https://logplex.heroku.com/channels \
   -H "Content-Type: application/json" \
@@ -38,14 +45,15 @@ $ curl -n -X POST https://logplex.heroku.com/channels \
     "your-token"
   ]
 }'
-
 ```
 
 
 #### Response Example
+
 ```
 HTTP/1.1 201 Created
 ```
+
 ```json
 {
   "channel_id": 123456,
@@ -57,6 +65,7 @@ HTTP/1.1 201 Created
 ```
 
 ### Channel Delete
+
 Delete an existing channel.
 
 ```
@@ -65,22 +74,25 @@ DELETE /v2/channels/{channel_channel_id}
 
 
 #### Curl Example
+
 ```bash
 $ curl -n -X DELETE https://logplex.heroku.com/v2/channels/$CHANNEL_CHANNEL_ID \
   -H "Content-Type: application/json" \
-
 ```
 
 
 #### Response Example
+
 ```
 HTTP/1.1 200 OK
 ```
+
 ```json
 
 ```
 
 ### Channel Info
+
 Info for existing channel.
 
 ```
@@ -89,16 +101,18 @@ GET /v2/channels/{channel_channel_id}
 
 
 #### Curl Example
-```bash
-$ curl -n -X GET https://logplex.heroku.com/v2/channels/$CHANNEL_CHANNEL_ID
 
+```bash
+$ curl -n https://logplex.heroku.com/v2/channels/$CHANNEL_CHANNEL_ID
 ```
 
 
 #### Response Example
+
 ```
 HTTP/1.1 200 OK
 ```
+
 ```json
 {
   "drains": [
@@ -119,16 +133,20 @@ HTTP/1.1 200 OK
 ```
 
 
-## Drain
+## <a name="resource-drain"></a>Drain
+
 Drains are log stream tee targets.
 
 ### Attributes
+
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
 | **id** | *integer* | unique identifier of drain | `123456` |
 | **token** | *string* | drain token | `"d.01234567-89ab-cdef-0123-456789abcdef"` |
 | **url** | *string* | drain destination | `"https://example.org"` |
+
 ### Drain Create
+
 Create a new drain.
 
 ```
@@ -136,6 +154,7 @@ POST /v2/channels/{channel_channel_id}/drains
 ```
 
 #### Required Parameters
+
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
 | **url** | *string* | drain destination | `"https://example.org"` |
@@ -143,6 +162,7 @@ POST /v2/channels/{channel_channel_id}/drains
 
 
 #### Curl Example
+
 ```bash
 $ curl -n -X POST https://logplex.heroku.com/v2/channels/$CHANNEL_CHANNEL_ID/drains \
   -H "Content-Type: application/json" \
@@ -150,14 +170,15 @@ $ curl -n -X POST https://logplex.heroku.com/v2/channels/$CHANNEL_CHANNEL_ID/dra
   -d '{
   "url": "https://example.org"
 }'
-
 ```
 
 
 #### Response Example
+
 ```
 HTTP/1.1 201 Created
 ```
+
 ```json
 {
   "id": 123456,
@@ -167,6 +188,7 @@ HTTP/1.1 201 Created
 ```
 
 ### Drain Delete
+
 Delete an existing drain.
 
 ```
@@ -175,22 +197,25 @@ DELETE /v2/channels/{channel_channel_id}/drains/{drain_id}
 
 
 #### Curl Example
+
 ```bash
 $ curl -n -X DELETE https://logplex.heroku.com/v2/channels/$CHANNEL_CHANNEL_ID/drains/$DRAIN_ID \
   -H "Content-Type: application/json" \
-
 ```
 
 
 #### Response Example
+
 ```
 HTTP/1.1 200 OK
 ```
+
 ```json
 
 ```
 
 ### Drain Update
+
 Update an existing drain.
 
 ```
@@ -198,6 +223,7 @@ POST /v2/channels/{channel_channel_id}/drains/{drain_id}
 ```
 
 #### Required Parameters
+
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
 | **url** | *string* | drain destination | `"https://example.org"` |
@@ -205,6 +231,7 @@ POST /v2/channels/{channel_channel_id}/drains/{drain_id}
 
 
 #### Curl Example
+
 ```bash
 $ curl -n -X POST https://logplex.heroku.com/v2/channels/$CHANNEL_CHANNEL_ID/drains/$DRAIN_ID \
   -H "Content-Type: application/json" \
@@ -212,14 +239,15 @@ $ curl -n -X POST https://logplex.heroku.com/v2/channels/$CHANNEL_CHANNEL_ID/dra
   -d '{
   "url": "https://example.org"
 }'
-
 ```
 
 
 #### Response Example
+
 ```
 HTTP/1.1 200 OK
 ```
+
 ```json
 {
   "id": 123456,
@@ -229,10 +257,12 @@ HTTP/1.1 200 OK
 ```
 
 
-## Healthchecks
+## <a name="resource-health"></a>Healthchecks
 
 
-### Healthchecks Check
+
+### Healthchecks 
+
 Performs a health check against the API.
 
 ```
@@ -241,31 +271,37 @@ GET /healthcheck
 
 
 #### Curl Example
-```bash
-$ curl -n -X GET https://logplex.heroku.com/healthcheck
 
+```bash
+$ curl -n https://logplex.heroku.com/healthcheck
 ```
 
 
 #### Response Example
+
 ```
 HTTP/1.1 200 OK
-
 ```
+
 ```json
-OK
-
+{
+  "status": "normal"
+}
 ```
 
 
-## Session
+## <a name="resource-session"></a>Session
+
 Sessions fetch recent and real-time logs from channels.
 
 ### Attributes
+
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
 | **url** | *string* | session URL to GET to retrieve logs | `"https://logplex.heroku.com/sessions/d58fb90e-c2bd-4e16-bfe0-e9e7cc7bff7f"` |
+
 ### Session Create
+
 Create a new session.
 
 ```
@@ -273,12 +309,14 @@ POST /v2/sessions
 ```
 
 #### Required Parameters
+
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
 | **channel_id** | *string* | unique identifier of channel (must be a string) | `"12345"` |
 
 
 #### Optional Parameters
+
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
 | **num** | *nullable string* | number of log lines to fetch<br/> **default:** `"100"` | `null` |
@@ -286,6 +324,7 @@ POST /v2/sessions
 
 
 #### Curl Example
+
 ```bash
 $ curl -n -X POST https://logplex.heroku.com/v2/sessions \
   -H "Content-Type: application/json" \
@@ -294,14 +333,15 @@ $ curl -n -X POST https://logplex.heroku.com/v2/sessions \
   "channel_id": "12345",
   "num": "5"
 }'
-
 ```
 
 
 #### Response Example
+
 ```
 HTTP/1.1 201 Created
 ```
+
 ```json
 {
   "url": "https://logplex.heroku.com/sessions/d58fb90e-c2bd-4e16-bfe0-e9e7cc7bff7f"
@@ -309,6 +349,7 @@ HTTP/1.1 201 Created
 ```
 
 ### Session Logs
+
 Get the chunk encoded session log data. If tail was specified the connection is long lived.
 
 ```
@@ -317,18 +358,20 @@ GET /sessions/{session_session_id}
 
 
 #### Curl Example
-```bash
-$ curl -n -X GET https://logplex.heroku.com/sessions/$SESSION_SESSION_ID
 
+```bash
+$ curl -n https://logplex.heroku.com/sessions/$SESSION_SESSION_ID
 ```
 
 
 #### Response Example
+
 ```
 HTTP/1.1 200 OK
 Transfer-Encoding: chunked
 
 ```
+
 ```json
 2012-12-10T03:00:48Z+00:00 app[console.1]: test message 1
 2012-12-10T03:00:49Z+00:00 app[console.1]: test message 2
@@ -339,15 +382,19 @@ Transfer-Encoding: chunked
 ```
 
 
-## Token
+## <a name="resource-token"></a>Token
+
 Tokens are log producers.
 
 ### Attributes
+
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
 | **token** | *string* | unique identifier of token | `"t.01234567-89ab-cdef-0123-456789abcdef"` |
 | **name** | *string* | name of token | `"my-token"` |
+
 ### Token Create
+
 Create a new token.
 
 ```
@@ -355,6 +402,7 @@ POST /v2/channels/{channel_channel_id}/tokens
 ```
 
 #### Required Parameters
+
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
 | **name** | *string* | name of token | `"my-token"` |
@@ -362,6 +410,7 @@ POST /v2/channels/{channel_channel_id}/tokens
 
 
 #### Curl Example
+
 ```bash
 $ curl -n -X POST https://logplex.heroku.com/v2/channels/$CHANNEL_CHANNEL_ID/tokens \
   -H "Content-Type: application/json" \
@@ -369,14 +418,15 @@ $ curl -n -X POST https://logplex.heroku.com/v2/channels/$CHANNEL_CHANNEL_ID/tok
   -d '{
   "name": "my-token"
 }'
-
 ```
 
 
 #### Response Example
+
 ```
 HTTP/1.1 201 Created
 ```
+
 ```json
 {
   "token": "t.01234567-89ab-cdef-0123-456789abcdef",

--- a/doc/schema/schemata/health.yaml
+++ b/doc/schema/schemata/health.yaml
@@ -1,19 +1,21 @@
 ---
 "$schema": http://json-schema.org/draft-04/hyper-schema
 title: Healthchecks
+definitions:
+  status:
+    description: API control rod status (normal, read_only)
+    example: normal
+    type:
+      - string
 links:
 - description: Performs a health check against the API.
   href: "/healthcheck"
   method: GET
-  type:
-  - string
-  rel: "empty"
-  response_example:
-    head: |
-      HTTP/1.1 200 OK
-    body: |
-      OK
-  title: Check
-type:
-  - object
+  rel: self
+  targetSchema:
+    type:
+      - object
+    properties:
+      status:
+        "$ref": "/schemata/health#/definitions/status"
 id: schemata/health

--- a/src/logplex_api.erl
+++ b/src/logplex_api.erl
@@ -102,7 +102,9 @@ handlers() ->
         Count = logplex_stats:healthcheck(),
         not is_integer(Count) andalso throw({500, io_lib:format("Increment healthcheck counter failed: ~p", [Count])}),
 
-        {200, <<"OK">>}
+        Info =[{status, status()}],
+
+        {200, ?JSON_CONTENT, iolist_to_binary(mochijson2:encode(Info))}
     end},
 
     {['POST', "/load$"], fun(Req, _Match, _Status) ->

--- a/src/nsync_callback.erl
+++ b/src/nsync_callback.erl
@@ -89,12 +89,10 @@ handle({cmd, "setex", [<<"session:", UUID/binary>>, _Expiry, Body]})
     catch logplex_session:store(UUID, Body),
     ?INFO("at=setex type=session id=~p", [UUID]);
 
-handle({cmd, "setbit", [<<"control_rod">>, <<"0">>, <<"1">>]}) ->
-    OldStatus = logplex_api:set_status(read_only),
-    ?INFO("at=setbit type=control_rod was=~p now=read_only", [OldStatus]);
-handle({cmd, "setbit", [<<"control_rod">>, <<"0">>, <<"0">>]}) ->
-    OldStatus = logplex_api:set_status(normal),
-    ?INFO("at=setbit type=control_rod was=~p now=read_only", [OldStatus]);
+handle({cmd, "setbit", [<<"control_rod">>, <<"0">>, BinValue]}) ->
+    Status = control_rod_flag(BinValue),
+    OldStatus = logplex_api:set_status(Status),
+    ?INFO("at=setbit type=control_rod was=~p now=~p", [OldStatus, Status]);
 
 handle({cmd, "del", []}) ->
     ok;
@@ -309,3 +307,6 @@ dict_find(Key, Dict, Default) ->
 
 drain_id(Bin) when is_binary(Bin) ->
     list_to_integer(binary_to_list(Bin)).
+
+control_rod_flag(<<"1">>) -> read_only;
+control_rod_flag(<<"0">>) -> normal.

--- a/src/nsync_callback.erl
+++ b/src/nsync_callback.erl
@@ -89,6 +89,13 @@ handle({cmd, "setex", [<<"session:", UUID/binary>>, _Expiry, Body]})
     catch logplex_session:store(UUID, Body),
     ?INFO("at=setex type=session id=~p", [UUID]);
 
+handle({cmd, "setbit", [<<"control_rod">>, <<"0">>, <<"1">>]}) ->
+    OldStatus = logplex_api:set_status(read_only),
+    ?INFO("at=setbit type=control_rod was=~p now=read_only", [OldStatus]);
+handle({cmd, "setbit", [<<"control_rod">>, <<"0">>, <<"0">>]}) ->
+    OldStatus = logplex_api:set_status(normal),
+    ?INFO("at=setbit type=control_rod was=~p now=read_only", [OldStatus]);
+
 handle({cmd, "del", []}) ->
     ok;
 handle({cmd, "del", [<<"ch:", Suffix/binary>> | Args]}) ->


### PR DESCRIPTION
It is now possible to use the redis config master to synchronize API
read_only control rods via nsync. To flag the API into read_only mode
use
```
SETBIT control_rod 0 1
```
to put the API back into normal operation use:
```
SETBIT control_rod 0 0
```