### PR TITLE
Docker compile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,21 @@
+dist: trusty
 language: erlang
-services:
-- redis-server
-before_install:
-- "./rebar --config public.rebar.config get-deps compile"
-script:
-- rebar get-deps compile --config test.rebar.config ; INSTANCE_NAME=`hostname` LOGPLEX_CONFIG_REDIS_URL='redis://localhost:6379'
-  LOGPLEX_SHARD_URLS='redis://localhost:6379' LOGPLEX_REDGRID_REDIS_URL='redis://localhost:6379'
-  LOCAL_IP='127.0.0.1' LOGPLEX_COOKIE=123 ERL_LIBS=`pwd`/deps/:$ERL_LIBS ct_run -spec
-  logplex.spec -pa ebin
+
 otp_release:
-  - 17.4
-  - R16B02
+  - R16B03-1
+
+before_install:
+  - .travis/install_compose.sh
+
+before_script:
+  - docker pull heroku/cedar:14
+  - docker pull voidlock/erlang:R16B03-1-onbuild
+  - docker pull redis:2.6
+
+script:
+  - docker-compose build
+  - docker-compose run test
+
 notifications:
   email: false
   hipchat:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 dist: trusty
-language: erlang
-
-otp_release:
-  - R16B03-1
+env:
+  COMPOSE_VERSION: 1.3.1
 
 before_install:
-  - .travis/install_compose.sh
+ - curl -L https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+ - chmod +x docker-compose
+ - sudo mv docker-compose /usr/local/bin
 
 before_script:
-  - docker pull heroku/cedar:14
   - docker pull voidlock/erlang:R16B03-1-onbuild
   - docker pull redis:2.6
 

--- a/.travis/install_compose.sh
+++ b/.travis/install_compose.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-curl -L https://github.com/docker/compose/releases/download/1.3.1/docker-compose-`uname -s`-`uname -m` > docker-compose
-chmod +x docker-compose
-sudo mv docker-compose /usr/local/bin

--- a/.travis/install_compose.sh
+++ b/.travis/install_compose.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+curl -L https://github.com/docker/compose/releases/download/1.3.1/docker-compose-`uname -s`-`uname -m` > docker-compose
+chmod +x docker-compose
+sudo mv docker-compose /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,7 @@ ENV ERL_CRASH_DUMP=/dev/null \
 
 EXPOSE 8001 8601 6001 4369 49000
 
+VOLUME /usr/src/app/deps
+VOLUME /usr/src/app/ebin
+
 CMD ["./bin/logplex"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: all compile quick get-deps dist-clean
+
+REBAR := ./rebar
+
+all : clean compile
+
+compile : get-deps
+	@$(REBAR) compile
+
+quick :
+	@$(REBAR) compile skip_deps=true
+
+get-deps :
+	@$(REBAR) get-deps
+
+clean :
+	@$(REBAR) clean
+
+dist-clean : clean
+	@rm -rf deps ebin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,22 +6,36 @@ db:
   command: redis-server
   volumes_from:
     - data
-logplex:
+base:
+  command: true
   build: .
+logplex:
+  image: logplex_base
   command: ./bin/compose_logplex
-  volumes:
-    - .:/usr/src/app
+  volumes_from:
+    - base
   ports:
     - "8001:8001"
     - "8601:8601"
     - "6001:6001"
   links:
     - db
+compile:
+  command: make quick
+  image: logplex_base
+  volumes:
+    - ./src:/usr/src/app/src
+  volumes_from:
+    - base
 test:
-  image: logplex_logplex
+  image: logplex_base
   command: bin/compose_test_logplex
   volumes:
-    - .:/usr/src/app
+    - ./src:/usr/src/app/src
+    - ./test:/usr/src/app/test
+    - ./logplex.spec:/usr/src/app/logplex.spec
+  volumes_from:
+    - base
   links:
     - db
 


### PR DESCRIPTION
This docker-compose configuration isolates the deps and ebin directories
into a base image. This base image is run as a data volume by the
logplex service and a new compile service.

```
docker-compose run compile
```

can be used to quickly rebuild the logplex source. To recompile
everything from scratch (including deps) use:

```
docker-compose run compile make all
```

The `Makefile` was added as a workaround to some kind of pseudo-tty bug
with rebar. Running the `rebar compile skip_deps=true` commands directly
Wwould result in rebar hanging. The inclusion of the `Makefile` or some
bash script to execute fixes that issue.

The next task will be to create docker-compose service that connects an
eshell to a running logplex service.