### PR TITLE
fixes git branch detection

### DIFF
--- a/src/logplex_app.erl
+++ b/src/logplex_app.erl
@@ -176,7 +176,7 @@ set_cookie() ->
 
 read_git_branch() ->
     GitOutput = hd(string:tokens(os:cmd("git status"), "\n")),
-    case re:run(GitOutput, "\# On branch (\\S+)", [{capture, all_but_first, list}]) of
+    case re:run(GitOutput, "On branch (\\S+)", [{capture, all_but_first, list}]) of
         {match,[Branch]} ->
             set_config(git_branch, Branch);
         _ ->


### PR DESCRIPTION
The format of the `git status` command changed at some point in newer
git versions. Looking for the leading # character is not necessary.

Resolves #138