### PR TITLE
some work to allow local drain testing

### DIFF
--- a/bin/papertrail-example.sh
+++ b/bin/papertrail-example.sh
@@ -48,11 +48,15 @@ GOPATH=`pwd`/tmp/go && \
     go get github.com/ddollar/forego
 PATH=`pwd`/tmp/go/bin:$PATH
 
+TAIL_SESSION=$(curl -H "Authorization: Basic ${LOGPLEX_AUTH_KEY}" -d "{\"channel_id\": \"$CHANNEL_ID\", \"tail\": \"true\"}" $LOGPLEX_URL/v2/sessions | jq -r '.url')
+echo "Tail session is: $LOGPLEX_URL$TAIL_SESSION"
+
 # Run spew and pipe to log-shuttle, and then to logplex channel
 echo "Running spew and log-shuttle (in background)"
 cat > tmp/Procfile <<EOF
 spew: DURATION=1s spew 2>&1 | log-shuttle -logplex-token=${CHANNEL_TOKEN} -logs-url="${LOGPLEX_LOGS_URL}/logs"
 papertrail: papertrail -f -d 1 ${DRAIN_TOKEN}
+tail: curl -s -N "$LOGPLEX_URL$TAIL_SESSION"
 EOF
 set -x
 forego start -f tmp/Procfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,20 @@ db:
   command: redis-server
   volumes_from:
     - data
+drain:
+  hostname: drain
+  domainname: heroku.local
+  image: 6cyx/basic-syslog-drain
+  ports:
+    - "6514:6514"
 base:
   command: /bin/true
   build: .
 logplex:
   image: logplex_base
   command: ./bin/compose_logplex
+  hostname: logplex
+  domainname: heroku.local
   env_file:
     - logplex.env
   volumes_from:
@@ -22,6 +30,7 @@ logplex:
     - "6001:6001"
   links:
     - db
+    - drain
 compile:
   command: make quick
   image: logplex_base


### PR DESCRIPTION
**Work in Progress**
- `bin/papertrail-example.sh` will now setup a local tail session too
- `docker-compose.yml` will start a drain service which logplex can be
  pointed at to deliver drains
