### PR TITLE
Fixes drain update logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV ERL_CRASH_DUMP=/dev/null \
 
 EXPOSE 8001 8601 6001 4369 49000
 
-VOLUME /usr/src/app/deps
-VOLUME /usr/src/app/ebin
+VOLUME /root/.cache
+VOLUME /usr/src/app/_build
 
 CMD ["./bin/logplex"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,24 @@ db:
 base:
   command: /bin/true
   build: .
+console:
+  image: logplex_base
+  command: ./_build/default/rel/logplex/bin/logplex console
+  hostname: logplex
+  domainname: docker.local
+  environment:
+    - INSTANCE_NAME=logplex.docker.local
+    - LOCAL_IP=127.0.0.1
+  env_file:
+    - logplex.env
+  volumes_from:
+    - base
+  ports:
+    - "8001:8001"
+    - "8601:8601"
+    - "6001:6001"
+  links:
+    - db
 logplex:
   image: logplex_base
   command: ./_build/default/rel/logplex/bin/logplex foreground

--- a/src/logplex_api.erl
+++ b/src/logplex_api.erl
@@ -390,24 +390,18 @@ handlers() ->
                                             [What]),
                         json_error(422, Err);
                     {valid, _, URI} ->
-                        case logplex_channel:can_add_drain(ChannelId) of
-                            cannot_add_drain ->
-                                logplex_drain:delete_partial_drain(DrainId, Token),
-                                json_error(422, <<"You have already added the maximum number of drains allowed">>);
-                            can_add_drain ->
-                                case logplex_drain:create(DrainId, Token, ChannelId, URI) of
-                                    {error, already_exists} ->
-                                        json_error(409, <<"Already exists">>);
-                                    {drain, _Id, Token} ->
-                                        Resp = [
-                                                {id, DrainId},
-                                                {token, Token},
-                                                {url, uri_to_binary(URI)}
-                                               ],
-                                        {201,?JSON_CONTENT,
-                                         mochijson2:encode({struct, Resp})}
-                                end
-                        end
+                    case logplex_drain:create(DrainId, Token, ChannelId, URI) of
+                      {error, already_exists} ->
+                        json_error(409, <<"Already exists">>);
+                      {drain, _Id, Token} ->
+                        Resp = [
+                                {id, DrainId},
+                                {token, Token},
+                                {url, uri_to_binary(URI)}
+                               ],
+                        {201,?JSON_CONTENT,
+                         mochijson2:encode({struct, Resp})}
+                    end
                 end
         end
     end},

--- a/src/logplex_tcpsyslog_drain.erl
+++ b/src/logplex_tcpsyslog_drain.erl
@@ -331,13 +331,18 @@ handle_info({tcp_closed, Sock}, StateName,
           "err=gen_tcp data=~p sock=~p duration=~s",
           log_info(State, [StateName, closed, Sock, duration(State)])),
     reconnect(tcp_bad(State));
-handle_info(shutdown, StateName, State = #state{sock = Sock})
+handle_info(shutdown, StateName, State0 = #state{sock = Sock})
   when is_port(Sock) ->
-    catch gen_tcp:close(Sock),
-    ?INFO("drain_id=~p channel_id=~p dest=~s state=~p "
-          "err=gen_tcp data=~p sock=~p duration=~s",
-          log_info(State, [StateName, shutdown, Sock, duration(State)])),
-    {stop, {shutdown,call}, State#state{sock = undefined}};
+    case send(State0) of
+      {next_state, ready_to_send, State1} ->
+        catch gen_tcp:close(Sock),
+        ?INFO("drain_id=~p channel_id=~p dest=~s state=~p "
+              "err=gen_tcp data=~p sock=~p duration=~s",
+              log_info(State1, [StateName, shutdown, Sock, duration(State1)])),
+        {stop, {shutdown,call}, State1#state{sock = undefined}};
+      {next_state, sending, State1} ->
+        handle_info(shutdown, StateName, State1)
+    end;
 handle_info(shutdown, _StateName, State) ->
     {stop, {shutdown,call}, State};
 %% close_timeout used to be called idle_timeout; remove once we are on v72+


### PR DESCRIPTION
Prior to this commit updates made using `/v2/channels/CHANNEL_ID/drains/DRAIN_ID` would update config redis and ETS on all clustered logplex nodes, but the `{error, {already_started, Pid}}` message was ignored. This meant that the updated drain URL would not take effect until after the logplex node had been restarted.

This isn't an ideal solution, since some loss could still occur. However, it is a quick fix until a more ideal in-place update can be made. Further refactoring of the drain FSMs will be required for that to take place.