### PR TITLE
Implement noverify opt out for TLS syslog drains

### DIFF
--- a/src/logplex_drain.erl
+++ b/src/logplex_drain.erl
@@ -55,6 +55,7 @@
          ,valid_uri/1
          ,has_valid_uri/1
          ,uri_schemes/0
+         ,uri_to_binary/1
         ]).
 
 -export([register/4

--- a/src/logplex_tls.erl
+++ b/src/logplex_tls.erl
@@ -7,7 +7,7 @@
 -module(logplex_tls).
 
 % Public API
--export([connect_opts/0,
+-export([connect_opts/1,
          max_depth/0,
          max_depth/1,
          cacertfile/0,
@@ -18,11 +18,15 @@
 -export([is_128_aes/1,
          verify/3]).
 
-connect_opts() ->
-  [{verify_fun, {fun verify/3, []}},
-   {depth, max_depth()},
-   {cacertfile, cacertfile()},
-   {ciphers, approved_ciphers()}]. 
+connect_opts(Insecure) ->
+    VerifyOpts = case Insecure of
+        true -> {verify, verify_none};
+        _    -> {verify_fun, {fun verify/3, []}}
+             end,
+    [VerifyOpts,
+     {depth, max_depth()},
+     {cacertfile, cacertfile()},
+     {ciphers, approved_ciphers()}].
 
 verify(_Cert,{bad_cert, _} = Reason, _) ->
   {fail, Reason};

--- a/src/logplex_tlssyslog_drain.erl
+++ b/src/logplex_tlssyslog_drain.erl
@@ -32,8 +32,7 @@
 %% API Function Exports
 %% ------------------------------------------------------------------
 
--export([start_link/5
-         ,resize_msg_buffer/2
+-export([resize_msg_buffer/2
          ,set_target_send_size/2
         ]).
 
@@ -41,6 +40,8 @@
          ,uri/2
          ,start_link/4
         ]).
+
+-export([unpack_uri/1, parse_fragment/1]).
 
 %% ------------------------------------------------------------------
 %% gen_fsm Function Exports
@@ -58,8 +59,10 @@
 -record(state, {drain_id :: logplex_drain:id(),
                 drain_tok :: logplex_drain:token(),
                 channel_id :: logplex_channel:id(),
+                uri :: #ex_uri{},
                 host :: string() | inet:ip_address() | binary(),
                 port :: inet:port_number(),
+                insecure :: boolean(),
                 sock = undefined :: 'undefined' | ssl:sslsocket(),
                 %% Buffer for messages while disconnected
                 buf = logplex_msg_buffer:new(default_buf_size()) :: logplex_msg_buffer:buf(),
@@ -84,20 +87,44 @@
 %% API Function Definitions
 %% ------------------------------------------------------------------
 
-start_link(ChannelID, DrainID, DrainTok,
-           #ex_uri{scheme="syslog+tls",
-                   authority=#ex_uri_authority{host=Host, port=Port}}) ->
-    start_link(ChannelID, DrainID, DrainTok, Host, Port).
-
-start_link(ChannelID, DrainID, DrainTok, Host, Port) ->
+start_link(ChannelID, DrainID, DrainTok, Uri) ->
+    {Host, Port, Insecure} = unpack_uri(Uri),
     gen_fsm:start_link(?MODULE,
                        [#state{drain_id=DrainID,
                                drain_tok=DrainTok,
                                channel_id=ChannelID,
+                               uri=Uri,
                                host=Host,
-                               port=Port}],
+                               port=Port,
+                               insecure=Insecure}],
                        []).
 
+unpack_uri(#ex_uri{scheme="syslog+tls",
+                  authority=#ex_uri_authority{host=Host, port=Port},
+                  fragment=Fragment}) ->
+    Opts =  parse_fragment(Fragment),
+    Insecure = case proplists:lookup("insecure", Opts) of
+                   {"insecure", "true"} -> true;
+                   _ -> false
+               end,
+    {Host, Port, Insecure}.
+
+parse_fragment(undefined) ->
+    [];
+parse_fragment(Fragment) ->
+    lists:map(fun (KeyValue) -> [K, V] = string:tokens(KeyValue, "="), {K,V} end,
+              string:tokens(Fragment, "&")).
+
+valid_uri(#ex_uri{scheme="syslog+tls",
+                  fragment=Fragment} = Uri)
+  when Fragment =/= undefined ->
+    try parse_fragment(Fragment) of
+        _ ->
+        valid_uri(Uri#ex_uri{fragment=undefined})
+    catch
+        error:_ ->
+            {error, invalid_tlssyslog_uri}
+    end;
 valid_uri(#ex_uri{scheme="syslog+tls",
                   authority=#ex_uri_authority{host=Host, port=Port}} = Uri)
   when is_list(Host), is_integer(Port),
@@ -146,8 +173,8 @@ init([State0 = #state{sock = undefined, host=H, port=P,
                                {H,P}),
         DrainSize = logplex_app:config(tcp_drain_buffer_size),
         State = State0#state{buf = logplex_msg_buffer:new(DrainSize)},
-        ?INFO("drain_id=~p channel_id=~p dest=~s at=spawn",
-              log_info(State, [])),
+        ?INFO("drain_id=~p channel_id=~p dest=~s insecure=~p at=spawn",
+              log_info(State, [State0#state.insecure])),
         {ok, disconnected,
          State, hibernate}
     catch
@@ -422,10 +449,10 @@ do_reconnect(State = #state{sock = undefined,
     end.
 
 %% @private
-connect(#state{sock = undefined, host=Host, port=Port})
+connect(#state{sock = undefined, host=Host, port=Port, insecure=Insecure})
     when is_integer(Port), 0 < Port, Port =< 65535 ->
     SendTimeoutS = logplex_app:config(tcp_syslog_send_timeout_secs),
-    TLSOpts = logplex_tls:connect_opts(),
+    TLSOpts = logplex_tls:connect_opts(Insecure),
     SocketOpts = socket_opts(),
     ssl:connect(Host, Port, TLSOpts ++ SocketOpts,
                 timer:seconds(SendTimeoutS));
@@ -518,9 +545,9 @@ time_failed(_, #state{last_good_time=undefined}) ->
     "".
 
 %% @private
-log_info(#state{drain_id=DrainId, channel_id=ChannelId, host=H, port=P}, Rest)
+log_info(#state{drain_id=DrainId, channel_id=ChannelId, uri=Uri}, Rest)
   when is_list(Rest) ->
-    [DrainId, ChannelId, logplex_logging:dest(H,P) | Rest].
+    [DrainId, ChannelId, logplex_drain:uri_to_binary(Uri) | Rest].
 
 -spec msg_stat('drain_dropped' | 'drain_buffered' | 'drain_delivered' |
                'requests_sent',

--- a/test/logplex_syslog_drain_SUITE.erl
+++ b/test/logplex_syslog_drain_SUITE.erl
@@ -10,7 +10,7 @@ all() -> [{group, tcp_syslog},
 
 groups() ->
   [{tcp_syslog, [], [{group, full_suite}]},
-   {tls_syslog, [], [{group, full_suite}, searches_to_max_depth]},
+   {tls_syslog, [], [{group, full_suite}, searches_to_max_depth, insecure_drain]},
    {full_suite, [], [writes_to_drain,
                      flushes_on_shutdown,
                      close_if_idle,
@@ -32,7 +32,7 @@ end_per_suite(_Config) ->
 init_per_group(DrainType, Config0) 
   when DrainType =:= tcp_syslog;
        DrainType =:= tls_syslog ->
-  [{drain_type, DrainType} | Config0];
+  [{drain_type, DrainType}, {port, 9071} | Config0];
 init_per_group(_Group, Config0) ->
   Config0.
 
@@ -46,12 +46,13 @@ init_per_testcase(shrinks, Config0) ->
   application:set_env(logplex, tcp_drain_buffer_size, MaxBufferSize),
   application:set_env(logplex, tcp_syslog_shrink_after, 1),
   init_per_testcase('_', [{max_buffer_size, MaxBufferSize} | Config0]);
-init_per_testcase(_TestCase, Config0) ->
+init_per_testcase(TestCase, Config0) ->
   % flushes session cache between runs
   ssl:stop(),
   ssl:start(),
-  Config1 = init_drain_endpoint(Config0),
+  Config1 = init_drain_endpoint(TestCase, Config0),
   init_logplex_drain(Config1).
+
 
 end_per_testcase(flushes_on_shutdown, _Config) ->
   end_drain_endpoint(),
@@ -78,25 +79,10 @@ wait_for_drain_(Prefix, Timeout) ->
       erlang:error({wait_timeout, Prefix})
   end.
 
-init_drain_endpoint(Config) ->
-  DrainType = ?config(drain_type, Config),
-  init_drain_endpoint(DrainType, Config).
-
-init_drain_endpoint(tcp_syslog, Config) ->
-  Port = 9601,
-  DrainURI = "syslog://127.0.0.1:" ++ integer_to_list(Port) ++ "/",
-  init_drain_endpoint(ranch_tcp, [{port, Port}], DrainURI, Config);
-init_drain_endpoint(tls_syslog, Config) ->
-  Port = 9601,
-  DrainURI = "syslog+tls://127.0.0.1:" ++ integer_to_list(Port) ++ "/",
-  CertsPath = filename:join([?config(data_dir, Config), "server"]),
-  init_drain_endpoint(ranch_ssl,
-                      [{port, Port},
-                       {cacertfile, filename:join([CertsPath, "cacerts.pem"])},
-                       {certfile, filename:join([CertsPath, "cert.pem"])},
-                       {keyfile, filename:join([CertsPath, "key.pem"])},
-                       {reuseaddr, true}],
-                      DrainURI, Config).
+init_drain_endpoint(TestCase, Config) ->
+  {Transport, TransportOpts} = transport_for_testcase(Config),
+  DrainURI = uri_for_testcase(TestCase, Config),
+  init_drain_endpoint(Transport, TransportOpts, DrainURI, Config).
 
 init_drain_endpoint(Transport, TransportOpts, URI, Config0) ->
   {ok, ExURI, _} = ex_uri:decode(URI),
@@ -108,6 +94,32 @@ init_drain_endpoint(Transport, TransportOpts, URI, Config0) ->
 
 end_drain_endpoint() ->
   ranch:stop_listener(drain_endpoint).
+
+uri_for_testcase(TestCase, Config) ->
+  Port = ?config(port, Config),
+  Scheme = case ?config(drain_type, Config) of
+               tcp_syslog -> "syslog://";
+               tls_syslog -> "syslog+tls://"
+           end,
+  Fragment = case TestCase of
+                 insecure_drain -> "#insecure=true";
+                 _              -> ""
+             end,
+  Scheme ++ "127.0.0.1:" ++ integer_to_list(Port) ++ "/" ++ Fragment.
+
+transport_for_testcase(Config) ->
+    transport_for_testcase(?config(drain_type, Config), Config).
+
+transport_for_testcase(tcp_syslog, Config) ->
+    {ranch_tcp, [{port, ?config(port, Config)}]};
+transport_for_testcase(tls_syslog, Config) ->
+    CertsPath = filename:join([?config(data_dir, Config), "server"]),
+    {ranch_ssl, [{port, ?config(port, Config)},
+                 {cacertfile, filename:join([CertsPath, "cacerts.pem"])},
+                 {certfile, filename:join([CertsPath, "cert.pem"])},
+                 {keyfile, filename:join([CertsPath, "key.pem"])},
+                 {reuseaddr, true}]}.
+
 
 drain_mod_for(tcp_syslog) ->
   logplex_tcpsyslog_drain;
@@ -152,7 +164,6 @@ writes_to_drain(Config) ->
   ok.
 
 searches_to_max_depth(Config) ->
-  ct:pal("CT_TESTCASE at=searches_to_max_depth"),
   ChannelID = ?config(channel_id, Config),
   DrainID = ?config(drain_id, Config),
 
@@ -170,6 +181,19 @@ searches_to_max_depth(Config) ->
 
   Pid = logplex_drain:whereis(DrainID),
   {disconnected, _} = recon:get_state(Pid),
+  ok.
+
+insecure_drain(Config) ->
+  ChannelID = ?config(channel_id, Config),
+
+  %% expects root ca
+  application:set_env(logplex, tls_max_depth, 0),
+
+  % triggers the drain to connect
+  logplex_channel:post_msg({channel, ChannelID}, fake_msg("ping")),
+  {ok, Log} = wait_for_log(),
+
+  {match, _} = re:run(Log, "ping"),
   ok.
 
 flushes_on_shutdown(Config) ->
@@ -233,7 +257,7 @@ backoff(Config) ->
   BackoffTime1 = timer:seconds(1 bsl 1)-500,
   timer:sleep(BackoffTime1),
 
-  init_drain_endpoint(Config),
+  init_drain_endpoint(backoff, Config),
   logplex_channel:post_msg({channel, ChannelID}, fake_msg("backoff 3: detects up")),
   {Time1, _} = timer:tc(fun wait_for_log/1, [BackoffTime1]),
 
@@ -241,7 +265,7 @@ backoff(Config) ->
   BackoffTime2 = timer:seconds(1 bsl 2)-500,
   timer:sleep(BackoffTime2),
 
-  init_drain_endpoint(Config),
+  init_drain_endpoint(backoff, Config),
   logplex_channel:post_msg({channel, ChannelID}, fake_msg("backoff 5: detects up")),
   {Time2, _} = timer:tc(fun wait_for_log/1, [BackoffTime2]),
 
@@ -249,7 +273,7 @@ backoff(Config) ->
   BackoffTime3 = timer:seconds(1 bsl 3)-500,
   timer:sleep(BackoffTime3),
 
-  init_drain_endpoint(Config),
+  init_drain_endpoint(backoff, Config),
   logplex_channel:post_msg({channel, ChannelID}, fake_msg("backoff 7: detects up")),
   {Time3, _} = timer:tc(fun wait_for_log/1, [BackoffTime3]),
 
@@ -275,7 +299,7 @@ shrinks(Config) ->
   [BufFiller(N) || N <- lists:seq(1, MaxBufferSize*2)],
   timer:sleep(timer:seconds(1 bsl 2)+500),
 
-  init_drain_endpoint(Config),
+  init_drain_endpoint(shrinks, Config),
 
   {ok, L10Error} = wait_for_log(),
   {match, _} = re:run(L10Error, "Error L10 "),

--- a/test/logplex_syslog_drain_SUITE.erl
+++ b/test/logplex_syslog_drain_SUITE.erl
@@ -102,7 +102,7 @@ uri_for_testcase(TestCase, Config) ->
                tls_syslog -> "syslog+tls://"
            end,
   Fragment = case TestCase of
-                 insecure_drain -> "#insecure=true";
+                 insecure_drain -> "#insecure";
                  _              -> ""
              end,
   Scheme ++ "127.0.0.1:" ++ integer_to_list(Port) ++ "/" ++ Fragment.


### PR DESCRIPTION
Configuration is done as part of the drain URI, for example:

    syslog+tls://myserver.com:8583/#insecure=true

Values other than "true" to the "insecure" URI fragment are implicitly treated
as a False.