### PR TITLE
support for pinned certificates

### DIFF
--- a/src/logplex.app.src
+++ b/src/logplex.app.src
@@ -82,6 +82,7 @@
     ,{workers, 10}
     ,{tls_max_depth, 9} % OpenSSL defaults to 100
     ,{tls_cacertfile, "cacert.pem"} % assumes stored in ./priv
+    ,{tls_pinned_certfile, "pinned_certs.pem"} % assumes stored in ./priv
    ]}
  ,{start_phases,
    [{listen, []}

--- a/src/logplex_app.erl
+++ b/src/logplex_app.erl
@@ -117,8 +117,10 @@ cache_os_envvars() ->
                         integer}
                       ,{api_endpoint_url, ["LOGPLEX_API_ENDPOINT_URL"],
                        optional}
-                      ,{tls_cacertfile, ["LOGPLEX_TLS_CACERTFILE"]}
-                      ,{tls_pinned_certfile, ["LOGPLEX_TLS_PINNED_CERTFILE"]}
+                      ,{tls_cacertfile, ["LOGPLEX_TLS_CACERTFILE"],
+                        optional}
+                      ,{tls_pinned_certfile, ["LOGPLEX_TLS_PINNED_CERTFILE"],
+                        optional}
                      ]),
     ok.
 

--- a/src/logplex_app.erl
+++ b/src/logplex_app.erl
@@ -117,6 +117,8 @@ cache_os_envvars() ->
                         integer}
                       ,{api_endpoint_url, ["LOGPLEX_API_ENDPOINT_URL"],
                        optional}
+                      ,{tls_cacertfile, ["LOGPLEX_TLS_CACERTFILE"]}
+                      ,{tls_pinned_certfile, ["LOGPLEX_TLS_PINNED_CERTFILE"]}
                      ]),
     ok.
 

--- a/src/logplex_tls.erl
+++ b/src/logplex_tls.erl
@@ -8,6 +8,7 @@
 
 -include("logplex_logging.hrl").
 -include_lib("ex_uri/include/ex_uri.hrl").
+-include_lib("public_key/include/public_key.hrl").
 
 %% Public API
 -export([connect_opts/3,
@@ -22,18 +23,18 @@
          verify_host/3,
          verify_none/3]).
 
--export([log_error/2]).
-
 -record(user_state, {channel_id :: logplex_channel:id(),
                      drain_id :: logplex_drain:id(),
                      dest :: #ex_uri{},
                      host :: ssl:host(),
-                     mode :: secure | insecure}).
+                     mode :: secure | insecure,
+                     depth = -1 :: pos_integer()}).
 
 connect_opts(ChannelID, DrainID, Dest) ->
     UserState = user_state(ChannelID, DrainID, Dest),
     [{verify_fun, verify_fun_and_data(UserState)},
      {depth, max_depth()},
+     {partial_chain, fun partial_chain/1},
      {reuse_sessions, false},
      {cacertfile, cacertfile()},
      {ciphers, approved_ciphers()}].
@@ -61,6 +62,9 @@ max_depth(Depth) ->
 cacertfile() ->
     filename:absname(logplex_app:config(tls_cacertfile), logplex_app:priv_dir()).
 
+pinned_certfile() ->
+    filename:absname(logplex_app:config(tls_pinned_certfile), logplex_app:priv_dir()).
+
 cacertfile(Path) ->
     application:set_env(logplex, tls_cacertfile, Path).
 
@@ -74,6 +78,50 @@ is_128_aes({_, aes_128_cbc, _}) -> true;
 is_128_aes({_, aes_128_gcm, _}) -> true;
 is_128_aes(_) -> false.
 
+partial_chain(Chain) ->
+    partial_chain(pinned_certs(), Chain).
+
+partial_chain([], _Chain) ->
+    unknown_ca;
+partial_chain(Pinned0, Chain0) ->
+    Certs = [{Cert, public_key:pkix_decode_cert(Cert, otp)} || Cert <- Chain0],
+    Pinned = [public_key:pkix_decode_cert(Cert, otp) || Cert <- Pinned0],
+    case find(fun({_, Cert}) ->
+                      check_cert(Pinned, Cert)
+              end, Certs) of
+        {ok, Trusted} -> {trusted_ca, element(1, Trusted)};
+        _ -> unknown_ca
+    end.
+
+extract_public_key_info(Cert) ->
+    ((Cert#'OTPCertificate'.tbsCertificate)#'OTPTBSCertificate'.subjectPublicKeyInfo).
+
+pinned_certs() ->
+    case file:read_file(pinned_certfile()) of
+        {ok, Certs} ->
+            Pems = public_key:pem_decode(Certs),
+            [Der || {'Certificate', Der, _} <- Pems];
+        {error, enoent} ->
+            []
+    end.
+
+check_cert(Pinned, Cert) ->
+    CertPubKey = extract_public_key_info(Cert),
+    lists:any(fun(CACert) ->
+                      CACertPubKey = extract_public_key_info(CACert),
+                      CertPubKey == CACertPubKey
+              end, Pinned).
+
+find(Fun, [Head|Tail]) when is_function(Fun) ->
+    case Fun(Head) of
+        true ->
+            {ok, Head};
+        false ->
+            find(Fun, Tail)
+    end;
+find(_Fun, []) ->
+    error.
+
 verify_none(_, {bad_cert, _}, UserState) ->
     {valid, UserState};
 verify_none(_, {extension, _}, UserState) ->
@@ -83,25 +131,38 @@ verify_none(_, valid, UserState) ->
 verify_none(_, valid_peer, UserState) ->
     {valid, UserState}.
 
-verify_host(_Cert, {bad_cert, _}=Reason, UserState) ->
-    log_error(Reason, UserState),
+verify_host(_Cert, {bad_cert, Reason}, UserState) ->
+    ?ERR("channel_id=~p drain_id=~p dest=~s depth=~b at=verify_host "
+         "err=bad_cert reason=~p",
+         log_args(UserState, [Reason])),
     {fail, Reason};
-verify_host(_Cert, {extension, _}=Reason, UserState) ->
-    {unknown, UserState};
-verify_host(_Cert, valid, UserState) ->
-    {valid, UserState};
+verify_host(_Cert, {extension, _}, UserState0) ->
+    {unknown, UserState0};
+verify_host(_Cert, valid, UserState0) ->
+    {valid, incr_depth(UserState0)};
 verify_host(Cert, valid_peer, #user_state{ host=Host }=UserState) ->
-    Reply = ssl_verify_hostname:verify_cert_hostname(Cert, Host),
-    handle_reply(Reply, UserState).
- 
+    try ssl_verify_hostname:verify_cert_hostname(Cert, Host) of
+        Reply -> handle_reply(Reply, UserState)
+    catch
+        Error:Reason ->
+            ?ERR("channel_id=~p drain_id=~p dest=~s depth=~b at=verify_host err=~p reason=~p trace=~p",
+                 log_args(UserState, [Error, Reason, erlang:get_stacktrace()])),
+            {fail, unexpected_error}
+    end.
+
 %% Private Functions
 
 handle_reply({valid, Host}, #user_state{ host=Host }=UserState) ->
-    {valid, UserState};
+    ?INFO("channel_id=~p drain_id=~p dest=~s depth=~b at=verify_host valid_peer=~p",
+         log_args(UserState, [Host])),
+    {valid, incr_depth(UserState)};
 handle_reply({fail, Reason}=Error, UserState) ->
-    log_error(Reason, UserState),
+    ?ERR("channel_id=~p drain_id=~p dest=~s depth=~b at=verify_host failure=Reason",
+         log_args(UserState, [Reason])),
     Error.
 
-log_error(Reason, #user_state{ channel_id=ChannelID, drain_id=DrainID, dest=Dest }) ->
-    ?ERR("channel_id=~p drain_id=~p dest=~s at=log_error err=~p",
-         [ChannelID, DrainID, logplex_drain:uri_to_binary(Dest), Reason]).
+log_args(#user_state{ channel_id=ChannelID, drain_id=DrainID, dest=Dest, depth=Depth }, Rest) ->
+    [ChannelID, DrainID, logplex_drain:uri_to_binary(Dest), Depth | Rest].
+
+incr_depth(#user_state{ depth=D }=UserState0) ->
+    UserState0#user_state{ depth=D+1 }.


### PR DESCRIPTION
Adds support for pinned certificates using the `partial_chain/1` hooks available to newer versions of Erlang. If pinning is not desired simply do not set the `LOGPLEX_TLS_PINNED_CERTFILE` environment variable or point it to an empty file.

Two new environment variables have been added to help customize the location of various certificate files.

`LOGPLEX_TLS_CACERTFILE` - the Root CA bundle in PEM format
`LOGPLEX_TLS_PINNED_CERTFILE` - the pinned certificate bundle in PEM format