### PR TITLE
support for pinning certs via OS var directly

### DIFF
--- a/src/logplex.app.src
+++ b/src/logplex.app.src
@@ -84,6 +84,7 @@
     ,{tls_max_depth, 9} % OpenSSL defaults to 100
     ,{tls_cacertfile, "cacert.pem"} % assumes stored in ./priv
     ,{tls_pinned_certfile, "pinned_certs.pem"} % assumes stored in ./priv
+    ,{tls_pinned_certs, []} % PEM formatted binary data or DER formatted list
    ]}
  ,{start_phases,
    [{listen, []}

--- a/src/logplex_app.erl
+++ b/src/logplex_app.erl
@@ -67,6 +67,7 @@ start(_StartType, _StartArgs) ->
     logplex_realtime:setup_metrics(),
     setup_redgrid_vals(),
     setup_redis_shards(),
+    logplex_tls:cache_env(),
     application:start(nsync),
     logplex_sup:start_link().
 
@@ -124,6 +125,9 @@ cache_os_envvars() ->
                         optional}
                       ,{tls_pinned_certfile, ["LOGPLEX_TLS_PINNED_CERTFILE"],
                         optional}
+                      ,{tls_pinned_certs, ["LOGPLEX_TLS_PINNED_CERTS"],
+                        optional,
+                        binary}
                      ]),
     ok.
 
@@ -158,6 +162,7 @@ set_config(Key, Value) when is_atom(Key) ->
     application:set_env(?APP, Key, Value).
 
 set_config_value(Value, string) -> Value;
+set_config_value(Value, binary) -> list_to_binary(Value);
 set_config_value(Value, atom) -> list_to_atom(Value);
 set_config_value(Value, integer) -> list_to_integer(Value).
 


### PR DESCRIPTION
Adds the ability to pin certificates via the `LOGPLEX_TLS_PINNED_CERTS`
OS environment variable. Logplex expects this variable to contain PEM
formatted certificates. The presence of this new variable supercedes any
file referenced by the `LOGPLEX_TLS_PINNED_CERTFILE` variable.

The certificates are processed and cached in DER format internally.