### PR TITLE
restrict TLS to 1.2 or 1.l

### DIFF
--- a/src/logplex.app.src
+++ b/src/logplex.app.src
@@ -81,7 +81,7 @@
     ,{http_drain_max_ttl, 18000000} % ms
     ,{workers, 10}
     ,{tls_mode, secure} % OpenSSL defaults to 100
-    ,{tls_versions, ['tlsv1.2', 'tlsv1.1']}  % Successfully TLS versions, see ssl:versions()
+    ,{tls_versions, ['tlsv1.2', 'tlsv1.1']}  % Sets TLS versions, see ssl:versions()
     ,{tls_max_depth, 9} % OpenSSL defaults to 100
     ,{tls_cacertfile, "cacert.pem"} % assumes stored in ./priv
     ,{tls_pinned_certfile, "pinned_certs.pem"} % assumes stored in ./priv

--- a/src/logplex.app.src
+++ b/src/logplex.app.src
@@ -81,6 +81,7 @@
     ,{http_drain_max_ttl, 18000000} % ms
     ,{workers, 10}
     ,{tls_mode, secure} % OpenSSL defaults to 100
+    ,{tls_versions, ['tlsv1.2', 'tlsv1.1']}  % Successfully TLS versions, see ssl:versions()
     ,{tls_max_depth, 9} % OpenSSL defaults to 100
     ,{tls_cacertfile, "cacert.pem"} % assumes stored in ./priv
     ,{tls_pinned_certfile, "pinned_certs.pem"} % assumes stored in ./priv

--- a/src/logplex_tls.erl
+++ b/src/logplex_tls.erl
@@ -22,6 +22,8 @@
          pinned_certfile/1,
          approved_ciphers/0,
          approved_ciphers/1,
+         approved_versions/0,
+         approved_versions/1,
          cache_env/0]).
 
 %% Internal API Exports

--- a/src/logplex_tls.erl
+++ b/src/logplex_tls.erl
@@ -49,7 +49,8 @@ connect_opts(ChannelID, DrainID, Dest) ->
      {partial_chain, fun partial_chain/1},
      {reuse_sessions, false},
      {cacertfile, cacertfile()},
-     {ciphers, approved_ciphers()}].
+     {ciphers, approved_ciphers()},
+     {versions, approved_versions()}].
 
 %% @doc Returns the maximum number of non Root CA certificates.
 %% @see ssl:ssloption()
@@ -115,6 +116,18 @@ approved_ciphers() ->
 
 approved_ciphers(Ciphers) when is_list(Ciphers) ->
     ?set_env(tls_ciphers, Ciphers).
+
+%% @doc Get the approved TLS versions.
+-spec approved_versions() -> [ssl:protocol()].
+
+approved_versions() ->
+    ?get_env(tls_versions).
+
+%% @doc Set the approved TLS versions.
+-spec approved_versions([ssl:protocol()]) -> ok.
+
+approved_versions(Versions) when is_list(Versions) ->
+    ?set_env(tls_ciphers, Versions).
 
 %% @doc Formats and caches various default settings.
 %% The following settings are cached.


### PR DESCRIPTION
TLS 1.0 is considered an early TLS, and is over 15 years old. PCI will
prohibit the use of 1.0 after June 2016.

This just sets some good patterns in place early on