### PR TITLE
HTTP idle fix

### DIFF
--- a/src/logplex_drain_buffer.erl
+++ b/src/logplex_drain_buffer.erl
@@ -50,8 +50,8 @@
          notify/2
         ]).
 
--export([post/2
-        ]).
+-export([post/2,
+         max_size/1]).
 
 %% ------------------------------------------------------------------
 %% gen_fsm Function Exports
@@ -106,6 +106,9 @@ resize_msg_buffer(Buffer, NewSize)
 
 post(Buffer, Msg) ->
     Buffer ! {post, Msg}.
+
+max_size(Buffer) ->
+    gen_fsm:sync_send_all_state_event(Buffer, max_size).
 
 %% ------------------------------------------------------------------
 %% gen_fsm Function Definitions
@@ -188,6 +191,8 @@ handle_event(_Event, StateName, State) ->
     {next_state, StateName, State, ?HIBERNATE_TIMEOUT}.
 
 %% @private
+handle_sync_event(max_size, _From, StateName, State=#state{buf=Buf}) ->
+    {reply, logplex_msg_buffer:max_size(Buf), StateName, State};
 handle_sync_event({resize_msg_buffer, NewSize}, _From, StateName, State=#state{buf=Buf}) ->
     NewBuf = logplex_msg_buffer:resize(NewSize, Buf),
     {reply, ok, StateName, State#state{buf=NewBuf}, ?HIBERNATE_TIMEOUT};

--- a/src/logplex_http_drain.erl
+++ b/src/logplex_http_drain.erl
@@ -650,7 +650,7 @@ close_if_idle(State = #state{client = Client}) ->
             ?INFO("drain_id=~p channel_id=~p dest=~s at=idle_timeout",
                   log_info(State, [])),
             logplex_http_client:close(Client),
-            {closed, State#state{client=undefined}};
+            {closed, State#state{client=undefined, last_good_time=never}};
         _ ->
             {not_closed, State}
     end.

--- a/src/logplex_http_drain.erl
+++ b/src/logplex_http_drain.erl
@@ -696,7 +696,8 @@ maybe_shrink(State = #state{last_good_time=never}) ->
     State#state{service=degraded};
 maybe_shrink(State = #state{buf=Buf, service=Status, last_good_time=LastGood}) ->
     MsecSinceLastGood = trunc(timer:now_diff(os:timestamp(), LastGood) / 1000),
-    case {MsecSinceLastGood > ?SHRINK_TIMEOUT, Status} of
+    ShrinkTimeout = logplex_app:config(http_drain_shrink_timeout, ?SHRINK_TIMEOUT),
+    case {MsecSinceLastGood > ShrinkTimeout, Status} of
         {true, normal} ->
             ?INFO("drain_id=~p channel_id=~p dest=~s at=maybe_shrink"
                   " service=~p time_since_last_good=~p",

--- a/test/logplex_http_drain_SUITE.erl
+++ b/test/logplex_http_drain_SUITE.erl
@@ -11,6 +11,8 @@ groups() -> [{overflow, [], [full_buffer_success, full_buffer_fail,
                              full_buffer_temp_fail, full_stack]},
              {drain_buf, [], [restart_drain_buf, shrink]}].
 
+
+-type drop_info() :: {erlang:timestamp(), pos_integer()}.
 -record(state, {drain_id :: logplex_drain:id(),
                 drain_tok :: logplex_drain:token(),
                 channel_id :: logplex_channel:id(),
@@ -20,11 +22,12 @@ groups() -> [{overflow, [], [full_buffer_success, full_buffer_fail,
                 out_q = queue:new() :: queue:queue(),
                 reconnect_tref :: reference() | 'undefined',
                 reconnect_attempt = 0 :: pos_integer(),
-                idle_tref :: reference() | 'undefined',
-                drop_info,
+                close_tref :: reference() | 'undefined',
+                drop_info :: drop_info() | 'undefined',
                 %% Last time we connected or successfully sent data
                 last_good_time = never :: 'never' | erlang:timestamp(),
                 service = normal :: 'normal' | 'degraded',
+                %% Time of last successful connection
                 connect_time :: 'undefined' | erlang:timestamp()
                }).
 
@@ -61,6 +64,11 @@ init_per_testcase(close_max_ttl, Config) ->
     application:set_env(logplex, http_drain_max_ttl, 100),
     Tab = init_http_mocks(),
     init_config(Config, Tab);
+init_per_testcase(shrink, Config) ->
+    application:set_env(logplex, http_drain_idle_timeout, 50),
+    application:set_env(logplex, http_drain_idle_fuzz, 1),
+    application:set_env(logplex, http_drain_shrink_timeout, 50),
+    init_per_testcase('_', Config);
 init_per_testcase(_, Config) ->
     Tab = init_http_mocks(),
     Ref = mock_drain_buffer(),
@@ -314,9 +322,12 @@ restart_drain_buf(Config) ->
     false = Buf0 =:= Buf1.
 
 shrink(Config) ->
+    ChannelId = ?config(channel, Config),
     Buf = ?config(buffer, Config),
+    CloseTref = make_ref(),
     State1 = #state{last_good_time={0,0,0},
                     buf = Buf,
+                    close_tref=CloseTref,
                     uri = ?config(uri, Config),
                     service=normal},
     meck:expect(logplex_http_client, start_link,
@@ -346,9 +357,27 @@ shrink(Config) ->
     Res2 = logplex_http_drain:disconnected({logplex_drain_buffer, Buf, new_data}, State2),
     {next_state, connected, State3=#state{service=degraded}, _} = Res2,
     Res3 = logplex_http_drain:connected({logplex_drain_buffer, Buf, {frame,<<"log lines">>, 15, 3}}, State3),
-    {next_state, connected, #state{service=normal}, _} = Res3,
+    {next_state, connected, State4=#state{service=normal}, _} = Res3,
     %% The buffer was resized
-    wait_for_mocked_call(logplex_drain_buffer, resize_msg_buffer, ['_',Val], 1, 1000).
+    wait_for_mocked_call(logplex_drain_buffer, resize_msg_buffer, ['_',Val], 1, 1000),
+
+    %% simulate idle connection timeout
+    meck:unload(logplex_drain_buffer),
+    {ok, Buffer} = logplex_drain_buffer:start_link(ChannelId),
+    State5 = State4#state{client={connected,client}, buf=Buffer, last_good_time={0,0,0}, close_tref=CloseTref},
+    ct:pal("Mocking idle timeout now ~p", [State5]),
+    Res4 = logplex_http_drain:connected({timeout, CloseTref, close_timeout}, State5),
+    
+    ct:pal("Result was: ~p", [Res4]),
+    {next_state, disconnected, State6=#state{client=undefined, service=normal}, hibernate} = Res4,
+
+    meck:expect(logplex_http_client, raw_request,
+                fun(_Pid, _Req, _Timeout) ->
+                        {ok, 504, []}
+                end),
+    logplex_http_drain:connected({logplex_drain_buffer, Buffer, {frame,<<"log lines">>, 15, 3}}, State6),
+    1024 = logplex_drain_buffer:max_size(Buffer),
+    ok.
 
 close_max_ttl(Config) ->
     ChannelId = ?config(channel, Config),
@@ -422,4 +451,4 @@ wait_for_dead_proc(Pid) ->
     end.
 
 fake_msg(M) ->
-    {user, debug, logplex_syslog_utils:datetime(now), "fakehost", "erlang", M}.
+    {user, debug, logplex_syslog_utils:datetime(now), "fakehost", "erlang", M ++ "\n"}.


### PR DESCRIPTION
Fixes a bug that causes the buffers to shrink if the connection immediately fails after the drain has idled out