### PR TITLE
don't track idle time towards buffer shrinking

### DIFF
--- a/src/logplex.app.src
+++ b/src/logplex.app.src
@@ -40,7 +40,7 @@
     ,{http_body_checksum, none} % none | md5
     ,{http_drain_buffer_size, 1024} % messages
     ,{http_drain_target_bytes, 102400} % bytes
-    ,{http_frame_retries, 1} % #extra attempts after first
+    ,{http_frame_retries, 2} % #extra attempts after first
     ,{http_log_input_port, 8601} % syslog/http tcp listen port
     ,{http_port, 8001}
     ,{http_reconnect_time, 10} % ms
@@ -71,7 +71,7 @@
     ,{tcp_syslog_reconnect_min, 30} % seconds
     ,{tcp_syslog_send_loss_msg, send} % send | dont_send
     ,{tcp_syslog_send_timeout_secs, 4} % seconds
-    ,{tcp_syslog_idle_timeout, 300000} % ms
+    ,{tcp_syslog_idle_timeout, 240000} % ms
     ,{tcp_syslog_idle_fuzz, 15000} % ms
     ,{tcp_syslog_max_ttl, 18000000} % ms
     ,{tcp_syslog_shrink_after, 10} % retry attempts

--- a/src/logplex_http_drain.erl
+++ b/src/logplex_http_drain.erl
@@ -152,7 +152,7 @@ disconnected(timeout, S = #state{}) ->
     %% Sleep when inactive, trigger fullsweep GC & Compact
     {next_state, disconnected, S, hibernate};
 disconnected({timeout, _Ref, ?CLOSE_TIMEOUT_MSG}, State) ->
-    {next_state, disconnected, State, hibernate};
+    {next_state, disconnected, State#state{last_good_time=never}, hibernate};
 disconnected(Msg, State) ->
     ?WARN("drain_id=~p channel_id=~p dest=~s err=unexpected_info "
           "data=\"~1000p\" state=disconnected",
@@ -254,10 +254,6 @@ handle_info({'EXIT', ClientPid, Reason}, StateName,
           "state=~p client_pid=~p err=~1000p",
           log_info(State, [StateName, ClientPid, Reason])),
     {next_state, StateName, State, ?HIBERNATE_TIMEOUT};
-
-%% close_timeout used to be called idle_timeout; remove once we are on v72+
-handle_info({timeout, TRef, idle_timeout}, StateName, State) ->
-    apply(?MODULE, StateName, [{timeout, TRef, ?CLOSE_TIMEOUT_MSG}, State]);
 
 handle_info(timeout, StateName, State) ->
     %% Sleep when inactive, trigger fullsweep GC & Compact
@@ -528,7 +524,7 @@ msg_stat(Key, N,
 %% and enqueue it.
 push_frame(FrameData, MsgCount, Lost, State = #state{out_q = Q})
   when not is_record(FrameData, frame) ->
-    Retries = logplex_app:config(http_frame_retries, 1),
+    Retries = logplex_app:config(http_frame_retries, 2),
     Tries = Retries + 1,
     Frame = #frame{frame=FrameData, msg_count=MsgCount,
                    loss_count=Lost,
@@ -631,10 +627,13 @@ ltcy(Start, End) ->
 
 start_close_timer(State=#state{close_tref = CloseTRef}) ->
     cancel_timeout(CloseTRef, ?CLOSE_TIMEOUT_MSG),
-    MaxIdle = logplex_app:config(http_drain_idle_timeout, timer:minutes(5)),
-    Fuzz = random:uniform(logplex_app:config(http_drain_idle_fuzz, 15000)),
+    MaxIdle = logplex_app:config(http_drain_idle_timeout, timer:minutes(4)),
+    Fuzz = random:uniform(max_idle_fuzz()),
     NewTimer = erlang:start_timer(MaxIdle + Fuzz, self(), ?CLOSE_TIMEOUT_MSG),
     State#state{close_tref = NewTimer}.
+
+max_idle_fuzz() ->
+    logplex_app:config(http_drain_idle_fuzz, 15000).
 
 compare_point(#state{last_good_time=never, connect_time=ConnectTime}) ->
     ConnectTime;
@@ -698,8 +697,7 @@ maybe_shrink(State = #state{last_good_time=never}) ->
     State#state{service=degraded};
 maybe_shrink(State = #state{buf=Buf, service=Status, last_good_time=LastGood}) ->
     MsecSinceLastGood = trunc(timer:now_diff(os:timestamp(), LastGood) / 1000),
-    ShrinkTimeout = logplex_app:config(http_drain_shrink_timeout, ?SHRINK_TIMEOUT),
-    case {MsecSinceLastGood > ShrinkTimeout, Status} of
+    case {MsecSinceLastGood > shrink_timeout(), Status} of
         {true, normal} ->
             ?INFO("drain_id=~p channel_id=~p dest=~s at=maybe_shrink"
                   " service=~p time_since_last_good=~p",
@@ -712,5 +710,8 @@ maybe_shrink(State = #state{buf=Buf, service=Status, last_good_time=LastGood}) -
                   log_info(State, [Status, MsecSinceLastGood])),
             State#state{service=Status}
     end.
+
+shrink_timeout() ->
+    erlang:max(max_idle_fuzz(), logplex_app:config(http_drain_shrink_timeout, ?SHRINK_TIMEOUT)).
 
 default_buf_size() -> logplex_app:config(http_drain_buffer_size, 1024).

--- a/test/logplex_http_drain_SUITE.erl
+++ b/test/logplex_http_drain_SUITE.erl
@@ -12,6 +12,10 @@ groups() -> [{overflow, [], [full_buffer_success, full_buffer_fail,
              {drain_buf, [], [restart_drain_buf, shrink]}].
 
 
+-ifdef(namespaced_types).
+-type queue() :: queue:queue().
+-endif.
+
 -type drop_info() :: {erlang:timestamp(), pos_integer()}.
 -record(state, {drain_id :: logplex_drain:id(),
                 drain_tok :: logplex_drain:token(),
@@ -221,7 +225,7 @@ full_buffer_temp_fail(Config) ->
 
     %% Here the drain should try connecting (and succeeding through mocks)
     %% and then set the buffer to active
-    1 = logplex_app:config(http_frame_retries, 1),
+    2 = logplex_app:config(http_frame_retries, 2),
     %% We send the message but expect it to fail 3 times before finally
     %% getting a 200 status code back.
     client_call_status(Client, {3, 500, 200}),


### PR DESCRIPTION
Addresses a few issues for low volume drains where the connecting
endpoint has closed the connection.

1. New logs could arrive after 5 minutes, but before the idle timeout
fuzz padding. The buffer would be immediately shrunk, when the send
fails.
2. Logs that failed to send, won't be retried until more logs enter the
drain, if the other end has closed the connection those re-framed logs
are lost after a single retry.
3. If the drain is in a disconnected state, the last known successfully
sent time isn't cleared when the idle timeout triggers.