### PR TITLE
retry http 429 responses

### DIFF
--- a/src/logplex_message.erl
+++ b/src/logplex_message.erl
@@ -87,9 +87,9 @@ process_error(ChannelID, Origin, ?L14, Fmt, Args) ->
     process_error(ChannelID, Origin, ["Error L14 (certificate validation): ", Fmt], Args).
 
 process_error(ChannelID, Origin, Fmt, Args) when is_list(Fmt), is_list(Args) ->
-    HerokuToken = logplex_token:lookup_heroku_token(ChannelID),
+    #token{ id=HerokuToken } = logplex_token:lookup_heroku_token(ChannelID),
     HerokuOrigin = <<"heroku">>,
-    do_process_error({HerokuToken#token.id, HerokuOrigin}, ChannelID, Origin, Fmt, Args).
+    do_process_error({HerokuToken, HerokuOrigin}, ChannelID, Origin, Fmt, Args).
 
 do_process_error({HerokuToken, HerokuOrigin}, ChannelID, Origin, Fmt, Args) when is_binary(HerokuToken) ->
     Msg = logplex_syslog_utils:fmt(local7,

--- a/test/logplex_http_drain_SUITE.erl
+++ b/test/logplex_http_drain_SUITE.erl
@@ -76,7 +76,9 @@ init_per_testcase(shrink, Config) ->
     application:set_env(logplex, http_drain_idle_timeout, 50),
     application:set_env(logplex, http_drain_idle_fuzz, 1),
     application:set_env(logplex, http_drain_shrink_timeout, 50),
-    init_per_testcase('_', Config);
+    Tab = init_http_mocks(),
+    Ref = mock_drain_buffer(),
+    [{buffer, Ref} | init_config(Config, Tab)];
 init_per_testcase(_, Config) ->
     Tab = init_http_mocks(),
     Ref = mock_drain_buffer(),

--- a/test/logplex_http_drain_SUITE.erl
+++ b/test/logplex_http_drain_SUITE.erl
@@ -397,6 +397,8 @@ shrink(Config) ->
                     close_tref=CloseTref,
                     uri = ?config(uri, Config),
                     service=normal},
+    meck:unload(logplex_http_client),
+    meck:new(logplex_http_client, [passthrough]),
     meck:expect(logplex_http_client, start_link,
         fun(_Drain, _Channel, _Uri, _Scheme, _Host, _Port, _Timeout) ->
             {error, mocked}
@@ -413,6 +415,8 @@ shrink(Config) ->
     %% This worked, so let's see the opposite -- that the size is brought back up
     %% to whatever configured value we have:
     Val = logplex_app:config(http_drain_buffer_size, 1024),
+    meck:unload(logplex_http_client),
+    meck:new(logplex_http_client, [passthrough]),
     meck:expect(logplex_http_client, start_link,
         fun(_Drain, _Channel, _Uri, _Scheme, _Host, _Port, _Timeout) ->
             {ok, self()}
@@ -438,6 +442,8 @@ shrink(Config) ->
     ct:pal("Result was: ~p", [Res4]),
     {next_state, disconnected, State6=#state{client=undefined, service=normal}, hibernate} = Res4,
 
+    meck:unload(logplex_http_client),
+    meck:new(logplex_http_client, [passthrough]),
     meck:expect(logplex_http_client, raw_request,
                 fun(_Pid, _Req, _Timeout) ->
                         {ok, 504, []}
@@ -447,6 +453,7 @@ shrink(Config) ->
 
     %% simulate idle connection timeout while connection is closed
     meck:unload(logplex_http_client),
+    meck:new(logplex_http_client, [passthrough]),
     State7 = State6#state{client=undefined, buf=Buffer, last_good_time={0,0,0}, close_tref=CloseTref},
     ct:pal("Mocking disconnected idle timeout now ~p", [State7]),
     Res5 = logplex_http_drain:disconnected({timeout, CloseTref, close_timeout}, State7),

--- a/test/logplex_http_drain_SUITE.erl
+++ b/test/logplex_http_drain_SUITE.erl
@@ -7,9 +7,13 @@ all() -> [{group, overflow},
           {group, drain_buf},
           close_max_ttl].
 
-groups() -> [{overflow, [], [full_buffer_success, full_buffer_fail,
-                             full_buffer_temp_fail, full_stack]},
-             {drain_buf, [], [restart_drain_buf, shrink]}].
+groups() -> [{overflow, [], [full_buffer_success,
+                             full_buffer_fail,
+                             full_buffer_temp_fail,
+                             full_buffer_http_retry,
+                             full_stack]},
+             {drain_buf, [], [restart_drain_buf,
+                              shrink]}].
 
 
 -ifdef(namespaced_types).
@@ -214,6 +218,63 @@ full_buffer_fail(Config) ->
     {match, _} = re:run(Success, Msg),
     %% (15 + 3) + 3 failures
     {match, _} = re:run(Success, "21 messages dropped").
+
+%% We drop frames twice, but the rest is successfully delivered. Overflow
+%% messages should be accumulated. This one experiments with temporary
+%% failure of delivery (429 range of HTTP responses)
+full_buffer_http_retry(Config) ->
+    Buf = ?config(buffer, Config),
+    Drain = ?config(drain, Config),
+    Client = ?config(client, Config),
+
+    %% Here the drain should try connecting (and succeeding through mocks)
+    %% and then set the buffer to active
+    2 = logplex_app:config(http_frame_retries, 2),
+    %% We send the message but expect it to fail 3 times before finally
+    %% getting a 200 status code back.
+    client_call_status(Client, {3, 429, 200}),
+    Msg = "some io data that represents 15 messages",
+    Frame = {frame, Msg, 15, 3},
+    Drain ! {logplex_drain_buffer, Buf, new_data},
+    Drain ! {logplex_drain_buffer, Buf, Frame},
+    %% When the drain fails temp, it closes the connection before continuing and
+    %% retrying again on the next frame sent
+    %% 1st frame: 15 queued, 3 lost (1 fail)
+    %% :: 0 global lost, 1 req
+    %%
+    %% We can now send a second frame and expect our errors
+    %% to be accumulated when the reconnection with the client is done.
+    Drain ! {logplex_drain_buffer, Buf, Frame},
+    %% 1st frame:  0 queued, 0 lost (dropped after 2 fails)
+    %% 2nd frame: 15 queued, 3 lost (0 attempt)
+    %% :: 18 global lost, 2 req
+    Drain ! {logplex_drain_buffer, Buf, Frame},
+    %% 2nd frame: 15 queued, 3 lost (1 fail)
+    %% 3rd frame: 15 queued, 3 lost (0 attempt)
+    %% :: 18 global lost, 3 req
+    %%
+    Drain ! {logplex_drain_buffer, Buf, Frame},
+    %% 2nd frame: delivered, 3+(15+3) lost (1 req)
+    %% 3rd frame: delivered, 3 lost (1 req)
+    %% 4th frame: delivered, 3 lost (1 req)
+    %% :: 18+3+3+3 = 27 global lost, (reqs for 3fail+3succeed = 6 total), 4 reconnections
+    wait_for_mocked_call(logplex_http_client, raw_request, '_', 6, 30000),
+    %% Everything is sent
+    6 = meck:num_calls(logplex_http_client, raw_request, '_'), % sends
+    Hist = meck:history(logplex_http_client),
+
+    [Fail1, Fail2, Fail3, Success1, Success2, Success3] =
+      [iolist_to_binary(IoData) || {_Pid, {_Mod, raw_request, [_Ref, IoData, _TimeOut]}, _Res} <- Hist],
+    {match, _} = re:run(Fail1, Msg), % temp 1st frame
+    {match, _} = re:run(Fail2, Msg), % permanent 1st frame
+    {match, _} = re:run(Fail3, Msg), % temp 2nd frame
+    {match, _} = re:run(Success1, Msg), % success 2nd frame
+    {match, _} = re:run(Success2, Msg), % success 3rd frame
+    {match, _} = re:run(Success3, Msg), % success 4th frame
+    %% 15 + 3 + 3 failures
+    {match, _} = re:run(Success1, "21 messages dropped"),
+    {match, _} = re:run(Success2, "3 messages dropped"),
+    {match, _} = re:run(Success3, "3 messages dropped").
 
 %% We drop frames twice, but the rest is successfully delivered. Overflow
 %% messages should be accumulated. This one experiments with temporary


### PR DESCRIPTION
A revival of an older 429 retry branch. This will have no effect for drains that hit their daily quota. The main goal of this change is to cope better when a drain spikes temporarily and get rate limited for a short period of time.