### PR TITLE
Merge v97 fixes

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -64,7 +64,7 @@
   0},
  {<<"nsync">>,
   {git,"git://github.com/heroku/nsync.git",
-       {ref,"687d499bcf14ecd87a44d416a58cf67c3f558fa5"}},
+       {ref,"df46d5315b94d71942599f15ff3187795e195085"}},
   0},
  {<<"pagerduty">>,
   {git,"git://github.com/heroku/pagerduty.git",


### PR DESCRIPTION
Merging the v97.fixes branch that pins nsync to a version that pins its dependencies.