### PR TITLE
add fragment-configured compression

### DIFF
--- a/src/logplex_http_drain.erl
+++ b/src/logplex_http_drain.erl
@@ -115,8 +115,8 @@ valid_uri(#ex_uri{scheme=Http,
 valid_uri(_) ->
     {error, invalid_http_uri}.
 
-is_compressed(#ex_uri{fragment=Fragment}) when is_list(Fragment) ->
-    lists:member("gzip", string:tokens(Fragment, "+"));
+is_compressed(#ex_uri{fragment="gzip"}) ->
+    true;
 is_compressed(_) ->
     false.
 


### PR DESCRIPTION
as per long-standing librato request, add the option to add a fragment to the target URI which will cause outgoing bodies to be gzipped and the header `Content-Encoding: gzip` to be added.

depending on the rate at which these get sent, we may wish to reuse the port, but since we don't know that we'll be limited by that, I chose the less complex implementation to start with.
