### PR TITLE
Revert "configure semver releases"

### DIFF
--- a/relx.config
+++ b/relx.config
@@ -1,5 +1,5 @@
 %% vim: set ts=2 sw=2 ft=erlang et:
-{release, {logplex, "semver"},
+{release, {logplex, "v89"},
  [logplex
   ,heroku_crashdumps
   ,recon]}.


### PR DESCRIPTION
This reverts commit edfc88cb2473fb0d6897fcf12410f9b357c6badd.

Switching to semver caused some internal deployment pain that I would rather punt on for now.