### PR TITLE
Move internal ID format to binaries

### DIFF
--- a/src/logplex.erl
+++ b/src/logplex.erl
@@ -24,7 +24,7 @@ serialize_from_token(TokenId) when is_binary(TokenId) ->
             serialize_channel(logplex_token:channel_id(Token))
     end.
 
-serialize_channel(ChannelId) when is_integer(ChannelId) ->
+serialize_channel(ChannelId) when is_binary(ChannelId) ->
     {logplex_channel:lookup(ChannelId),
      logplex_token:lookup_by_channel(ChannelId),
      logplex_drain:lookup_by_channel(ChannelId)}.
@@ -42,7 +42,7 @@ deserialize_channel({Chan,
 drain_dests() ->
     logplex_drain:by_dest().
 
-post_to_channel(ChannelId, Fmt, Args) when is_integer(ChannelId) ->
+post_to_channel(ChannelId, Fmt, Args) when is_binary(ChannelId) ->
     logplex_channel:post_msg({channel, ChannelId},
                              logplex_syslog_utils:fmt('user', 'debug', now,
                                                       "erlang", "shell",

--- a/src/logplex_app.erl
+++ b/src/logplex_app.erl
@@ -100,7 +100,7 @@ cache_os_envvars() ->
                       ,{instance_name, ["INSTANCE_NAME"]}
                       ,{metrics_channel_id, ["METRICS_CHANNEL_ID"],
                         optional,
-                        integer}
+                        binary}
                       ,{firehose_channel_ids, ["FIREHOSE_CHANNEL_IDS"],
                         optional}
                       ,{firehose_filter_tokens, ["FIREHOSE_FILTER_TOKENS"],

--- a/src/logplex_cred.erl
+++ b/src/logplex_cred.erl
@@ -138,7 +138,7 @@ grant(Perm, Cred = #cred{perms = Perms}) ->
 -spec valid_perm(any()) -> 'valid' | 'invalid'.
 valid_perm(full_api) -> valid;
 valid_perm(any_channel) -> valid;
-valid_perm({channel, Id}) when is_integer(Id) -> valid;
+valid_perm({channel, Id}) when is_binary(Id) -> valid;
 valid_perm(_) -> invalid.
 
 -spec has_perm(perm(), #cred{}) -> 'permitted' | 'not_permitted'.
@@ -193,8 +193,7 @@ cred_from_dict(<<"full_api">>, _, Cred = #cred{perms = Perms}) ->
     Cred#cred{perms = ordsets:add_element(full_api, Perms)};
 cred_from_dict(<<"channel">>, <<"any">>, Cred = #cred{perms = Perms}) ->
     Cred#cred{perms = ordsets:add_element(any_channel, Perms)};
-cred_from_dict(<<"channel">>, ChannelIdB, Cred = #cred{perms = Perms}) ->
-    ChannelId = logplex_channel:binary_to_id(ChannelIdB),
+cred_from_dict(<<"channel">>, ChannelId, Cred = #cred{perms = Perms}) ->
     Cred#cred{perms = ordsets:add_element({chan, ChannelId}, Perms)};
 
 cred_from_dict(Key, Value, Cred) ->
@@ -206,7 +205,7 @@ perms_to_dict(Perms) ->
     [ case Perm of
           full_api -> {<<"full_api">>, <<"1">>};
           any_channel -> {<<"channel">>, <<"any">>};
-          {channel, Id} -> {<<"channel">>, logplex_channel:id_to_binary(Id)}
+          {channel, Id} -> {<<"channel">>, Id}
       end
       || Perm <- ordsets:to_list(Perms) ].
 

--- a/src/logplex_drain.erl
+++ b/src/logplex_drain.erl
@@ -191,14 +191,14 @@ lookup_token(DrainId) when is_integer(DrainId) ->
 
 store_token(DrainId, Token, ChannelId) when is_integer(DrainId),
                                             is_binary(Token),
-                                            is_integer(ChannelId) ->
+                                            is_binary(ChannelId) ->
     true = ets:insert(drains, #drain{id=DrainId, token=Token,
                                      channel_id=ChannelId}),
     ok.
 
 cache(DrainId, Token, ChannelId) when is_integer(DrainId),
                                       is_binary(Token),
-                                      is_integer(ChannelId) ->
+                                      is_binary(ChannelId) ->
     redis_helper:reserve_drain(DrainId, Token, ChannelId).
 
 -spec create(logplex_channel:id(), #ex_uri{}) ->
@@ -219,7 +219,7 @@ create(ChannelId, URI) ->
 create(DrainId, Token, ChannelId, URI)
   when is_integer(DrainId),
        is_binary(Token),
-       is_integer(ChannelId) ->
+       is_binary(ChannelId) ->
     case ets:match_object(drains, #drain{channel_id=ChannelId,
                                          uri=URI, _='_'}) of
         [_] ->
@@ -302,7 +302,7 @@ has_valid_uri(#drain{uri=Uri}) ->
         _ -> false
     end.
 
-delete_by_channel(ChannelId) when is_integer(ChannelId) ->
+delete_by_channel(ChannelId) when is_binary(ChannelId) ->
     Drains = ets:select(drains,
                         ets:fun2ms(fun (#drain{id=Id,channel_id=C})
                                         when C =:= ChannelId ->
@@ -312,7 +312,7 @@ delete_by_channel(ChannelId) when is_integer(ChannelId) ->
     ok.
 
 
-count_by_channel(ChannelId) when is_integer(ChannelId) ->
+count_by_channel(ChannelId) when is_binary(ChannelId) ->
     ets:select_count(drains,
                      ets:fun2ms(fun (#drain{channel_id=C,
                                             uri = Uri})
@@ -322,7 +322,7 @@ count_by_channel(ChannelId) when is_integer(ChannelId) ->
                                 end)).
 
 
-lookup_by_channel(ChannelId) when is_integer(ChannelId) ->
+lookup_by_channel(ChannelId) when is_binary(ChannelId) ->
     ets:select(drains,
                ets:fun2ms(fun (#drain{channel_id=C})
                                 when C =:= ChannelId ->
@@ -332,7 +332,7 @@ lookup_by_channel(ChannelId) when is_integer(ChannelId) ->
 
 -spec register(id(), logplex_channel:id(), atom(), term()) -> ok.
 register(DrainId, ChannelId, Type, Dest)
-  when is_integer(DrainId), is_integer(ChannelId) ->
+  when is_integer(DrainId), is_binary(ChannelId) ->
     logplex_channel:register({channel, ChannelId}),
     register(DrainId, Type, Dest).
 

--- a/src/logplex_drain_buffer.erl
+++ b/src/logplex_drain_buffer.erl
@@ -76,7 +76,7 @@ start_link(ChannelId, Owner) ->
                  Owner::pid(),
                  'passive' | 'notify', Size::pos_integer()) -> any().
 start_link(ChannelId, Owner, Mode, Size)
-  when is_integer(ChannelId),
+  when is_binary(ChannelId),
        is_pid(Owner),
        Mode =:= passive orelse Mode =:= notify,
        is_integer(Size), Size > 0 ->
@@ -119,7 +119,7 @@ init({Mode, S = #state{channel_id = ChannelId,
                        owner = Owner,
                        buf_size = Size}})
   when Mode =:= notify orelse Mode =:= passive,
-       is_pid(Owner), is_integer(ChannelId) ->
+       is_pid(Owner), is_binary(ChannelId) ->
     logplex_channel:register({channel, ChannelId}),
     {ok, Mode, S#state{buf = logplex_msg_buffer:new(Size)}}.
 

--- a/src/logplex_http_client.erl
+++ b/src/logplex_http_client.erl
@@ -56,13 +56,13 @@ init([State = #state{},
                               Host, Port, Client0) of
         {ok, Client} ->
             ConnectEnd = os:timestamp(),
-            ?INFO("drain_id=~p channel_id=~p dest=~s at=try_connect "
+            ?INFO("drain_id=~p channel_id=~s dest=~s at=try_connect "
                   "attempt=success connect_time=~p",
                   log_info(State, [ltcy(ConnectStart, ConnectEnd)])),
             {ok, State#state{client=Client}};
         {error, Why} ->
             ConnectEnd = os:timestamp(),
-            ?WARN("drain_id=~p channel_id=~p dest=~s at=try_connect "
+            ?WARN("drain_id=~p channel_id=~s dest=~s at=try_connect "
                   "attempt=fail connect_time=~p tcp_err=~1000p",
                   log_info(State, [ltcy(ConnectStart, ConnectEnd), Why])),
             ignore
@@ -70,7 +70,7 @@ init([State = #state{},
         Class:Err ->
             Report = {Class, Err, erlang:get_stacktrace()},
             ConnectEnd = os:timestamp(),
-            ?WARN("drain_id=~p channel_id=~p dest=~s at=connect "
+            ?WARN("drain_id=~p channel_id=~s dest=~s at=connect "
                   "attempt=fail err=exception connect_time=~p "
                   "next_state=disconnected "
                   "data=~1000p",
@@ -86,7 +86,7 @@ handle_call({raw_request, Req}, _From, State) ->
             {reply, {ok, Status, Headers}, NewState};
         {error, Why} = Err ->
             ReqEnd = os:timestamp(),
-            ?WARN("drain_id=~p channel_id=~p dest=~s at=response"
+            ?WARN("drain_id=~p channel_id=~s dest=~s at=response"
                   " result=error req_time=~p tcp_err=\"~1000p\"",
                   log_info(State, [ltcy(ReqStart, ReqEnd), Why])),
             {stop, normal, Err, State}

--- a/src/logplex_logs_rest.erl
+++ b/src/logplex_logs_rest.erl
@@ -171,7 +171,7 @@ from_logplex(Req, State = #state{token = Token,
     case parse_logplex_body(Req, State) of
         {parsed, Req2, State2 = #state{msgs = Msgs}}
           when is_list(Msgs), is_binary(Token),
-                 is_integer(ChannelId), is_binary(Name) ->
+                 is_binary(ChannelId), is_binary(Name) ->
             logplex_message:process_msgs(Msgs, ChannelId, Token, Name),
             {true, Req2, State2#state{msgs = []}};
         {parsed, Req2, State2 = #state{msgs = Msgs}}
@@ -184,13 +184,13 @@ from_logplex(Req, State = #state{token = Token,
         {{error, malformed_messages}, Req2, State2} ->
             %% XXX - Add stat counter here?
             respond(400, <<"Malformed log messages">>, Req2, State2);
-        {{error, Reason}, Req2, State2} when is_integer(ChannelId) ->
-            ?WARN("at=parse_logplex_body channel_id=~p error=~p",
+        {{error, Reason}, Req2, State2} when is_binary(ChannelId) ->
+            ?WARN("at=parse_logplex_body channel_id=~s error=~p",
                   [ChannelId, Reason]),
             respond(400, <<"Bad request">>, Req2, State2);
         {{error, Reason}, Req2, State2} when ChannelId =:= any ->
-            ?WARN("at=parse_logplex_body channel_id=~p error=~p",
-                  [ChannelId, Reason]),
+            ?WARN("at=parse_logplex_body channel_id=any error=~p",
+                  [Reason]),
             respond(400, <<"Bad request">>, Req2, State2)
     end.
 

--- a/src/logplex_message.erl
+++ b/src/logplex_message.erl
@@ -66,7 +66,7 @@ process_msg({msg, RawMsg}, ChannelId, Token, TokenName, ShardInfo)
     process_msg(RawMsg, ChannelId, Token, TokenName, ShardInfo);
 process_msg(RawMsg, ChannelId, Token, TokenName, ShardInfo)
   when is_binary(RawMsg),
-       is_integer(ChannelId),
+       is_binary(ChannelId),
        is_binary(Token),
        is_binary(TokenName) ->
     logplex_stats:incr(message_received),
@@ -74,7 +74,7 @@ process_msg(RawMsg, ChannelId, Token, TokenName, ShardInfo)
     case logplex_channel:lookup_flag(no_redis, ChannelId) of
         not_found ->
             logplex_realtime:incr(unknown_channel),
-            ?INFO("at=process_msg channel_id=~p msg=unknown_channel", [ChannelId]);
+            ?INFO("at=process_msg channel_id=~s msg=unknown_channel", [ChannelId]);
         Flag ->
             CookedMsg = iolist_to_binary(re:replace(RawMsg, Token, TokenName)),
             logplex_firehose:post_msg(ChannelId, TokenName, RawMsg),
@@ -130,7 +130,7 @@ process_redis(ChannelId, ShardInfo, Msg, _Flag) ->
     Expiry = logplex_app:config(redis_buffer_expiry),
     HistorySize = logplex_app:config(log_history),
     {Map, Interval} = logplex_shard_info:map_interval(ShardInfo),
-    BufferPid = logplex_shard:lookup(integer_to_list(ChannelId),
+    BufferPid = logplex_shard:lookup(binary_to_list(ChannelId),
                                      Map, Interval),
     Cmd = redis_helper:build_push_msg(ChannelId, HistorySize,
                                       Msg, Expiry),

--- a/src/logplex_stats.erl
+++ b/src/logplex_stats.erl
@@ -155,14 +155,14 @@ start_timer() ->
     erlang:start_timer(Time, ?MODULE, flush).
 
 log_stat(UnixTS, {drain_stat, DrainId, ChannelId, Key}, Val) ->
-    ?METRIC("m=logplex_stats ts=~p channel_id=~p drain_id=~p ~p=~p~n",
+    ?METRIC("m=logplex_stats ts=~p channel_id=~s drain_id=~p ~p=~p~n",
           [UnixTS, ChannelId, DrainId, Key, Val]);
 log_stat(UnixTS, #drain_stat{drain_id=DrainId, drain_type=DrainType, channel_id=ChannelId, key=Key}, Val) ->
-    ?METRIC("m=logplex_stats ts=~p channel_id=~p drain_id=~p drain_type=~p ~p=~p~n",
+    ?METRIC("m=logplex_stats ts=~p channel_id=~s drain_id=~p drain_type=~p ~p=~p~n",
           [UnixTS, ChannelId, DrainId, DrainType, Key, Val]);
 
 log_stat(UnixTS, #channel_stat{channel_id=ChannelId, key=Key}, Val) ->
-    ?METRIC("m=logplex_stats ts=~p channel_id=~p ~p=~p~n",
+    ?METRIC("m=logplex_stats ts=~p channel_id=~s ~p=~p~n",
           [UnixTS, ChannelId, Key, Val]);
 
 log_stat(UnixTS, #logplex_stat{module=Mod, key=K}, Val) ->

--- a/src/logplex_tail.erl
+++ b/src/logplex_tail.erl
@@ -36,19 +36,19 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
-register(ChannelId) when is_integer(ChannelId) ->
+register(ChannelId) when is_binary(ChannelId) ->
     put(logplex_tail, {channel_id, ChannelId}), %% post mortem debug info
     Self = self(),
     gen_server:abcast([node()|nodes()], ?MODULE, {register, ChannelId, Self}),
     ok.
 
-route(ChannelId, Msg) when is_integer(ChannelId), is_binary(Msg) ->
+route(ChannelId, Msg) when is_binary(ChannelId), is_binary(Msg) ->
     [Pid ! {log, Msg} || {_ChannelId, Pid} <- ets:lookup(?MODULE, ChannelId)],
     ok.
 
 %% @doc Shut down a running tail - intended for use when no_tail is
 %% added to a channel.
-shutdown(ChannelId) when is_integer(ChannelId) ->
+shutdown(ChannelId) when is_binary(ChannelId) ->
     [exit(Pid, shutdown)
      || {_ChannelId, Pid} <- ets:lookup(?MODULE, ChannelId)],
     ok.

--- a/src/logplex_tail_buffer.erl
+++ b/src/logplex_tail_buffer.erl
@@ -137,7 +137,7 @@ send(S = #state{owner = Owner, buf = Buf,
 check_overload(#state{channel_id=Id}) ->
     case process_info(self(), message_queue_len) of
         {message_queue_len, N} when N > 100000 ->
-            ?ERR("channel_id=~p error=tail_buffer_overload msg_q_len=~p",
+            ?ERR("channel_id=~s error=tail_buffer_overload msg_q_len=~p",
                  [Id, N]),
             erlang:exit(normal);
         _ ->

--- a/src/logplex_tls.erl
+++ b/src/logplex_tls.erl
@@ -182,7 +182,7 @@ verify_none(_, valid_peer, UserState) ->
     {valid, UserState}.
 
 verify_host(_Cert, {bad_cert, Reason}, UserState) ->
-    ?ERR("channel_id=~p drain_id=~p dest=~s depth=~b at=verify_host "
+    ?ERR("channel_id=~s drain_id=~p dest=~s depth=~b at=verify_host "
          "err=bad_cert reason=~p",
          log_args(UserState, [Reason])),
     {fail, Reason};
@@ -194,12 +194,12 @@ verify_host(Cert, valid_peer, #user_state{ host=Host }=UserState) ->
     try ssl_verify_hostname:verify_cert_hostname(Cert, Host) of
         {valid, Host} -> {valid, incr_depth(UserState)};
         {fail, Reason}=Error ->
-            ?ERR("channel_id=~p drain_id=~p dest=~s depth=~b at=verify_host failure=Reason",
+            ?ERR("channel_id=~s drain_id=~p dest=~s depth=~b at=verify_host failure=Reason",
                  log_args(UserState, [Reason])),
             Error
     catch
         Error:Reason ->
-            ?ERR("channel_id=~p drain_id=~p dest=~s depth=~b at=verify_host err=~p reason=~p trace=~p",
+            ?ERR("channel_id=~s drain_id=~p dest=~s depth=~b at=verify_host err=~p reason=~p trace=~p",
                  log_args(UserState, [Error, Reason, erlang:get_stacktrace()])),
             {fail, unexpected_error}
     end.

--- a/src/logplex_token.erl
+++ b/src/logplex_token.erl
@@ -69,11 +69,11 @@
 -define(CHAN_TOKEN_TAB, channel_tokens).
 
 new(Id, ChannelId, Name)
-  when is_binary(Id), is_integer(ChannelId), is_binary(Name) ->
+  when is_binary(Id), is_binary(ChannelId), is_binary(Name) ->
     #token{id = Id, channel_id = ChannelId, name = Name}.
 
 new(ChannelId, Name)
-  when is_integer(ChannelId), is_binary(Name) ->
+  when is_binary(ChannelId), is_binary(Name) ->
     new(new_unique_token_id(), ChannelId, Name).
 
 id(#token{id=Id}) -> Id.
@@ -89,7 +89,7 @@ create_ets_table() ->
                               {read_concurrency, true},
                               {write_concurrency, true}]).
 
-create(ChannelId, TokenName) when is_integer(ChannelId), is_binary(TokenName) ->
+create(ChannelId, TokenName) when is_binary(ChannelId), is_binary(TokenName) ->
     TokenId = new_unique_token_id(),
     case store(new(TokenId, ChannelId, TokenName)) of
         ok ->
@@ -153,7 +153,7 @@ delete_by_id(Id) ->
             ok
     end.
 
-delete_by_channel(ChannelId) when is_integer(ChannelId) ->
+delete_by_channel(ChannelId) when is_binary(ChannelId) ->
     [ delete(Token)
       || Token <- lookup_by_channel(ChannelId)],
     ok.
@@ -167,7 +167,7 @@ lookup_by_channel(ChannelId) ->
                   end,
                   lookup_ids_by_channel(ChannelId)).
 
-lookup_ids_by_channel(ChannelId) when is_integer(ChannelId) ->
+lookup_ids_by_channel(ChannelId) when is_binary(ChannelId) ->
     ets:select(?CHAN_TOKEN_TAB,
                [{#token_idx{key = {ChannelId, '$1'}},[],['$1']}]).
 

--- a/src/logplex_udpsyslog_drain.erl
+++ b/src/logplex_udpsyslog_drain.erl
@@ -95,7 +95,7 @@ init([State = #state{drain_id=DrainId, channel_id=ChannelId,
   when H =/= undefined, is_integer(P) ->
     try
         logplex_drain:register(DrainId, ChannelId, udpsyslog, {H,P}),
-        ?INFO("drain_id=~p channel_id=~p dest=~s at=spawn",
+        ?INFO("drain_id=~p channel_id=~s dest=~s at=spawn",
               log_info(State, [])),
         {ok, State, hibernate}
     catch
@@ -104,7 +104,7 @@ init([State = #state{drain_id=DrainId, channel_id=ChannelId,
 
 %% @private
 handle_call(Call, _From, State) ->
-    ?WARN("drain_id=~p channel_id=~p dest=~s err=unexpected_call data=~p",
+    ?WARN("drain_id=~p channel_id=~s dest=~s err=unexpected_call data=~p",
           log_info(State, [Call])),
     {noreply, State}.
 
@@ -113,7 +113,7 @@ handle_cast(shutdown, State) ->
     {stop, normal, State};
 
 handle_cast(Msg, State) ->
-    ?WARN("drain_id=~p channel_id=~p dest=~s err=unexpected_cast data=~p",
+    ?WARN("drain_id=~p channel_id=~s dest=~s err=unexpected_cast data=~p",
           log_info(State, [Msg])),
     {noreply, State}.
 
@@ -122,7 +122,7 @@ handle_info({post, Msg}, State = #state{sock = undefined})
   when is_tuple(Msg) ->
     case connect(State) of
         {ok, Addr, Sock} ->
-            ?INFO("drain_id=~p channel_id=~p dest=~s at=connect try=~p addr=~s",
+            ?INFO("drain_id=~p channel_id=~s dest=~s at=connect try=~p addr=~s",
                   log_info(State, [State#state.failures + 1,
                                    host_str(Addr)])),
             handle_info({post, Msg},
@@ -130,7 +130,7 @@ handle_info({post, Msg}, State = #state{sock = undefined})
         {error, Reason} ->
             NewState = udp_bad(State#state{sock=undefined}),
             msg_stat(drain_dropped, 1, NewState),
-            ?ERR("drain_id=~p channel_id=~p dest=~s at=connect "
+            ?ERR("drain_id=~p channel_id=~s dest=~s at=connect "
                  "err=gen_udp data=~p try=~p last_success=~s",
                  log_info(State, [Reason, NewState#state.failures,
                                   time_failed(NewState)])),
@@ -146,19 +146,19 @@ handle_info({post, Msg}, State = #state{}) when is_tuple(Msg) ->
         {error, Reason} ->
             NewState = udp_bad(State#state{sock=undefined}),
             msg_stat(drain_dropped, 1, State),
-            ?ERR("drain_id=~p channel_id=~p dest=~s at=post "
+            ?ERR("drain_id=~p channel_id=~s dest=~s at=post "
                  "err=gen_udp data=~p",
                  log_info(NewState, [Reason])),
             {noreply, NewState}
     end;
 
 handle_info({udp, S, _IP, _Port, Data}, State = #state{sock = S}) ->
-    ?WARN("drain_id=~p channel_id=~p dest=~s err=unexpected_peer_data data=~p",
+    ?WARN("drain_id=~p channel_id=~s dest=~s err=unexpected_peer_data data=~p",
           log_info(State, [Data])),
     {noreply, State};
 
 handle_info(Info, State) ->
-    ?WARN("drain_id=~p channel_id=~p dest=~s err=unexpected_info data=~p",
+    ?WARN("drain_id=~p channel_id=~s dest=~s err=unexpected_info data=~p",
           log_info(State, [Info])),
     {noreply, State}.
 

--- a/src/nsync_callback.erl
+++ b/src/nsync_callback.erl
@@ -32,7 +32,7 @@
 
 %% LOAD
 handle({load, <<"ch:", Rest/binary>>, Dict}) when is_tuple(Dict) ->
-    Id = logplex_channel:binary_to_id(parse_id(Rest)),
+    Id = parse_id(Rest),
     create_channel(Id, Dict);
 
 handle({load, <<"tok:", Rest/binary>>, Dict}) when is_tuple(Dict) ->
@@ -63,9 +63,9 @@ handle({load, eof}) ->
 
 %% STREAM
 handle({cmd, "hmset", [<<"ch:", Rest/binary>> | Args]}) ->
-    Id = logplex_channel:binary_to_id(parse_id(Rest)),
+    Id = parse_id(Rest),
     Dict = dict_from_list(Args),
-    ?INFO("at=set type=channel id=~p", [Id]),
+    ?INFO("at=set type=channel id=~s", [Id]),
     create_channel(Id, Dict);
 
 handle({cmd, "hmset", [<<"tok:", Rest/binary>> | Args]}) ->
@@ -99,8 +99,8 @@ handle({cmd, "setbit", [<<"control_rod">>, <<"0">>, BinValue]}) ->
 handle({cmd, "del", []}) ->
     ok;
 handle({cmd, "del", [<<"ch:", Suffix/binary>> | Args]}) ->
-    Id = logplex_channel:binary_to_id(parse_id(Suffix)),
-    ?INFO("at=delete type=channel id=~p", [Id]),
+    Id = parse_id(Suffix),
+    ?INFO("at=delete type=channel id=~s", [Id]),
     ets:delete(channels, Id),
     handle({cmd, "del", Args});
 handle({cmd, "del", [<<"tok:", Suffix/binary>> | Args]}) ->
@@ -194,7 +194,7 @@ find_token(Id, Dict) ->
         undefined ->
             {error, missing_channel};
         Val1 ->
-            Ch = convert_to_integer(Val1),
+            Ch = iolist_to_binary(Val1),
             Name = dict_find(<<"name">>, Dict),
             Token = logplex_token:new(Id, Ch, Name),
             {ok, Token}
@@ -218,7 +218,7 @@ create_or_update_drain(Id, Dict) ->
             ?ERR("~p ~p ~p ~p",
                  [create_drain, missing_ch, Id, dict:to_list(Dict)]);
         Val1 ->
-            Ch = convert_to_integer(Val1),
+            Ch = iolist_to_binary(Val1),
             case dict_find(<<"token">>, Dict) of
                 undefined ->
                     ?ERR("~p ~p ~p ~p",
@@ -227,7 +227,7 @@ create_or_update_drain(Id, Dict) ->
                     case drain_uri(Dict) of
                         partial_drain_record ->
                             ?INFO("at=partial_drain_record drain_id=~p "
-                                  "token=~p channel=~p",
+                                  "token=~p channel=~s",
                                   [Id, Token, Ch]),
                             logplex_drain:store_token(Id, Token, Ch);
                         Uri ->
@@ -286,11 +286,6 @@ drain_uri(Dict) ->
 parse_id(Bin) ->
     [Id | _] = binary:split(Bin, <<":">>),
     Id.
-
-convert_to_integer(V) when is_binary(V) ->
-    list_to_integer(binary_to_list(V));
-convert_to_integer(V) when is_list(V) ->
-    list_to_integer(V).
 
 dict_from_list(List) ->
     dict_from_list(List, dict:new()).

--- a/test/logplex_channel_SUITE.erl
+++ b/test/logplex_channel_SUITE.erl
@@ -46,7 +46,7 @@ end_per_testcase(_CaseName, Config) ->
 %%%%%%%%%%%%%
 
 properties(_Config) ->
-    Channel = {channel, 2189312},
+    Channel = {channel, <<"2189312">>},
     Msg1 = msg(term_to_binary(make_ref())),
     Msg2 = msg(term_to_binary(make_ref())),
     S = self(),

--- a/test/logplex_firehose_SUITE.erl
+++ b/test/logplex_firehose_SUITE.erl
@@ -42,8 +42,8 @@ end_per_testcase(_CaseName, Config) ->
 %%%%%%%%%%%%%
 
 master_config(_Config) ->
-    FirehoseChannelId = 21894100,
-    ChannelId = 21894200,
+    FirehoseChannelId = <<"21894100">>,
+    ChannelId = <<"21894200">>,
 
     logplex_firehose:create_ets_tables(),
     logplex_firehose:enable(),
@@ -51,7 +51,7 @@ master_config(_Config) ->
     undefined = logplex_firehose:next_shard(ChannelId, <<"app">>),
     undefined = logplex_firehose:next_shard(ChannelId, <<"filtered">>),
 
-    application:set_env(logplex, firehose_channel_ids, lists:concat([FirehoseChannelId])),
+    application:set_env(logplex, firehose_channel_ids, lists:concat([binary_to_list(FirehoseChannelId)])),
     application:set_env(logplex, firehose_filter_tokens, "filtered"),
     logplex_firehose:enable(),
 
@@ -66,8 +66,8 @@ master_config(_Config) ->
     ok.
 
 post_msg(_Config) ->
-    FirehoseChannelId = 21894100,
-    ChannelId = 21894200,
+    FirehoseChannelId = <<"21894100">>,
+    ChannelId = <<"21894200">>,
     Msg1 = term_to_binary(make_ref()),
     Msg2 = term_to_binary(make_ref()),
     Msg3 = term_to_binary(make_ref()),
@@ -81,7 +81,7 @@ post_msg(_Config) ->
     ok = logplex_firehose:post_msg(ChannelId, <<"heroku">>, Msg1),
     false = meck:called(logplex_channel, post_msg, [{channel, FirehoseChannelId}, Msg1]),
 
-    application:set_env(logplex, firehose_channel_ids, lists:concat([FirehoseChannelId])),
+    application:set_env(logplex, firehose_channel_ids, lists:concat([binary_to_list(FirehoseChannelId)])),
     application:set_env(logplex, firehose_filter_tokens, "heroku"),
     logplex_firehose:create_ets_tables(),
     logplex_firehose:enable(),
@@ -104,7 +104,7 @@ post_msg(_Config) ->
 
 distribution(_Config) ->
     FirehoseChannelId = "21894100,21894101",
-    ChannelId = 21894200,
+    ChannelId = <<"21894200">>,
 
     meck:expect(logplex_channel, post_msg, [{[{channel, '_'}, '_'], ok}]),
 
@@ -128,8 +128,8 @@ distribution(_Config) ->
             timeout
     end,
 
-    Calls1 = meck:num_calls(logplex_channel, post_msg, [{channel,21894100}, '_']),
-    Calls2 = meck:num_calls(logplex_channel, post_msg, [{channel,21894101}, '_']),
+    Calls1 = meck:num_calls(logplex_channel, post_msg, [{channel,<<"21894100">>}, '_']),
+    Calls2 = meck:num_calls(logplex_channel, post_msg, [{channel,<<"21894101">>}, '_']),
     ct:pal("channel_id=~p calls=~p", [21894100, Calls1]),
     ct:pal("channel_id=~p calls=~p", [21894101, Calls2]),
 

--- a/test/logplex_http_drain_SUITE.erl
+++ b/test/logplex_http_drain_SUITE.erl
@@ -490,7 +490,7 @@ close_max_ttl(Config) ->
 
 %%% HELPERS
 init_config(Config, Tab) ->
-    ChannelId = 1337,
+    ChannelId = <<"1337">>,
     DrainId = 2198712,
     DrainTok = "d.12930-321-312213-12321",
     {ok,URI,_} = ex_uri:decode("http://example.org"),

--- a/test/logplex_logs_rest_SUITE.erl
+++ b/test/logplex_logs_rest_SUITE.erl
@@ -57,7 +57,7 @@ v2_redirects(Config) ->
     BasicAuth = ?config(auth, Config),
     Logs = ?config(logs, Config) ++ "/v2/channels/",
     ChannelId = ?config(channel_id, Config),
-    Get = Logs ++ integer_to_list(ChannelId),
+    Get = Logs ++ binary_to_list(ChannelId),
     %% Get = ?config(logs, Config) ++ "/healthcheck",
     Res = logplex_api_SUITE:get_(Get, [{headers, [{"Authorization", BasicAuth}]},
                                        {http_opts, [{autoredirect, false}]}]),
@@ -69,7 +69,7 @@ v1_redirects_channels(Config) ->
     ChannelId = ?config(channel_id, Config),
     Get = binary_to_list(iolist_to_binary([?config(logs, Config),
            "/channels/",
-           integer_to_list(ChannelId),
+           binary_to_list(ChannelId),
            "/info"])),
     Res = logplex_api_SUITE:get_(Get, [{headers, [{"Authorization", BasicAuth}]},
                                        {http_opts, [{autoredirect, false}]}]),
@@ -94,7 +94,7 @@ post_logline(Config) ->
                 fun(Req, State) ->
                         State1 = setelement(2, State, Token),
                         State2 = setelement(3, State1, <<"dont'care">>),
-                        State3 = setelement(4, State2, 3),
+                        State3 = setelement(4, State2, <<"3">>),
                         {true, Req, State3}
                 end),
     PostRes = logplex_api_SUITE:post(Post, [{headers, [{"Authorization", BasicAuth}]},
@@ -130,7 +130,7 @@ post_logline_compressed(Config) ->
                         %%                 msgs :: list()}).
                         State1 = setelement(2, State, Token),
                         State2 = setelement(3, State1, <<"dont'care">>),
-                        State3 = setelement(4, State2, 3),
+                        State3 = setelement(4, State2, <<"3">>),
                         {true, Req, State3}
                 end),
     Body = ?BODY(Token),

--- a/test/logplex_syslog_drain_SUITE.erl
+++ b/test/logplex_syslog_drain_SUITE.erl
@@ -139,7 +139,7 @@ init_logplex_drain(Config) ->
     init_logplex_drain(drain_mod_for(DrainType), Config).
 
 init_logplex_drain(DrainMod, Config0) ->
-    ChannelID = 1337,
+    ChannelID = <<"1337">>,
     DrainID = 31337,
     DrainTok = "d.12930-321-312213-12321",
     HerokuToken = #token{ id = <<"t.mocked-token">>,

--- a/test/logplex_token_SUITE.erl
+++ b/test/logplex_token_SUITE.erl
@@ -37,7 +37,7 @@ init_per_testcase(by_id, Config) ->
     Config;
 init_per_testcase(by_channel, Config) ->
     logplex_db:start_link(),
-    [{chan, 1} | Config];
+    [{chan, <<"1">>} | Config];
 init_per_testcase(_CaseName, Config) ->
     Config.
 
@@ -67,7 +67,7 @@ by_channel(Config) ->
     ok.
 
 by_id(_Config) ->
-    Chan = 2,
+    Chan = <<"2">>,
     Id = <<"t.1">>,
     BobT = logplex_token:new(Id, Chan, <<"bob">>),
     undefined = logplex_token:lookup(Id),

--- a/test/tcp_proxy_SUITE.erl
+++ b/test/tcp_proxy_SUITE.erl
@@ -28,7 +28,7 @@ end_per_testcase(_Case, Config) ->
 accepts_tcp_syslog_data(Config) ->
     Sock = ?config(socket, Config),
     Token = #token{id = <<"t.d6799f88-4a77-402f-b197-2b722a02cdbc">>,
-                   channel_id = 12345,
+                   channel_id = <<"12345">>,
                    name = <<"test">>},
     meck:expect(logplex_token, lookup, fun(Id) when Id =:= Token#token.id -> Token end),
     meck:expect(logplex_channel, lookup_flag, [no_redis, Token#token.channel_id], meck:val(no_such_flag)),
@@ -49,7 +49,7 @@ accepts_tcp_syslog_data(Config) ->
 rejects_newline_delimited_data(Config) ->
     Sock = ?config(socket, Config),
     Token = #token{id = <<"t.d6799f88-4a77-402f-b197-2b722a02cdbc">>,
-                   channel_id = 12345,
+                   channel_id = <<"12345">>,
                    name = <<"test">>},
 
     meck:expect(logplex_realtime, incr, fun(_Key) -> ok end),


### PR DESCRIPTION
- this allows to support UUIDs eventually
- this likely breaks the multi-node tail support since the registration
  globally is done with the channel id. For the duration of a potential
  roll-out, tails will be only partially working
- the API has a backwards-compat mode just in case, but only when
  possible (IDs are integers)
- added a simple test to ensure we couldn't pass non-integer IDs through the
  API since that could lead to redis injection -- regexes protect us
  there so it's only a regression