### PR TITLE
Proposal for v3 api

### DIFF
--- a/doc/schema/schema.json
+++ b/doc/schema/schema.json
@@ -9,10 +9,17 @@
       "title": "Channel",
       "definitions": {
         "channel_id": {
-          "description": "unique identifier of channel",
+          "description": "unique identifier of a channel (deprecated)",
           "example": 123456,
           "type": [
             "integer"
+          ]
+        },
+        "channel": {
+          "description": "unique identifier of a channel",
+          "example": "123456",
+          "type": [
+            "string"
           ]
         },
         "drains": {
@@ -96,7 +103,7 @@
               }
             }
           },
-          "title": "Create"
+          "title": "Create (Deprecated)"
         },
         {
           "description": "Delete an existing channel.",
@@ -106,7 +113,7 @@
           "response_example": {
             "head": "HTTP/1.1 200 OK"
           },
-          "title": "Delete",
+          "title": "Delete (Deprecated)",
           "type": [
             null
           ]
@@ -116,15 +123,127 @@
           "href": "/v2/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
-          "title": "Info",
+          "title": "Info (Deprecated)",
+          "targetSchema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "channel_id": {
+                "$ref": "#/definitions/channel/definitions/channel_id"
+              },
+              "tokens": {
+                "description": "created token names and tokens",
+                "example": {
+                  "my-token": "t.01234567-89ab-cdef-0123-456789abcdef",
+                  "your-token": "t.5b432a82-2c03-4ecd-a8d4-a75d627b29ab"
+                },
+                "type": [
+                  "object"
+                ]
+              }
+            }
+          },
           "type": [
             "object"
+          ]
+        },
+        {
+          "description": "Create or update a channel.",
+          "href": "/v3/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fchannel)}",
+          "method": "PUT",
+          "rel": "create_or_update",
+          "schema": {
+            "properties": {
+              "tokens": {
+                "description": "names of tokens to create",
+                "example": [
+                  "my-token",
+                  "your-token"
+                ],
+                "items": {
+                  "type": [
+                    "string"
+                  ]
+                },
+                "type": [
+                  "array"
+                ]
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "channel": {
+                "$ref": "#/definitions/channel/definitions/channel"
+              },
+              "tokens": {
+                "description": "token names and tokens",
+                "example": {
+                  "my-token": "t.01234567-89ab-cdef-0123-456789abcdef",
+                  "your-token": "t.5b432a82-2c03-4ecd-a8d4-a75d627b29ab"
+                },
+                "type": [
+                  "object"
+                ]
+              }
+            }
+          },
+          "title": "Create or Update"
+        },
+        {
+          "description": "Info for existing channel.",
+          "href": "/v3/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fchannel)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info",
+          "targetSchema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "channel": {
+                "$ref": "#/definitions/channel/definitions/channel"
+              },
+              "tokens": {
+                "description": "token names and tokens",
+                "example": {
+                  "my-token": "t.01234567-89ab-cdef-0123-456789abcdef",
+                  "your-token": "t.5b432a82-2c03-4ecd-a8d4-a75d627b29ab"
+                },
+                "type": [
+                  "object"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "description": "Delete an existing channel.",
+          "href": "/v3/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fchannel)}",
+          "method": "DELETE",
+          "rel": "empty",
+          "response_example": {
+            "head": "HTTP/1.1 204 No Content"
+          },
+          "title": "Delete",
+          "type": [
+            null
           ]
         }
       ],
       "properties": {
         "drains": {
           "$ref": "#/definitions/channel/definitions/drains"
+        },
+        "channel": {
+          "$ref": "#/definitions/channel/definitions/channel"
         },
         "channel_id": {
           "$ref": "#/definitions/channel/definitions/channel_id"
@@ -200,6 +319,26 @@
               "object"
             ]
           },
+          "title": "Create (Deprecated)"
+        },
+        {
+          "description": "Create a new drain.",
+          "href": "/v3/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fchannel)}/drains",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "url": {
+                "$ref": "#/definitions/drain/definitions/url"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": [
+              "object"
+            ]
+          },
           "title": "Create"
         },
         {
@@ -210,6 +349,19 @@
           "response_example": {
             "head": "HTTP/1.1 200 OK"
           },
+          "title": "Delete (Deprecated)",
+          "type": [
+            null
+          ]
+        },
+        {
+          "description": "Delete an existing drain.",
+          "href": "/v3/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fchannel)}/drains/{(%23%2Fdefinitions%2Fdrain%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "empty",
+          "response_example": {
+            "head": "HTTP/1.1 204 No Content"
+          },
           "title": "Delete",
           "type": [
             null
@@ -219,6 +371,26 @@
           "description": "Update an existing drain.",
           "href": "/v2/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fidentity)}/drains/{(%23%2Fdefinitions%2Fdrain%2Fdefinitions%2Fidentity)}",
           "method": "POST",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "url": {
+                "$ref": "#/definitions/drain/definitions/url"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Update (Deprecated)"
+        },
+        {
+          "description": "Update an existing drain.",
+          "href": "/v3/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fchannel)}/drains/{(%23%2Fdefinitions%2Fdrain%2Fdefinitions%2Fidentity)}",
+          "method": "PUT",
           "rel": "update",
           "schema": {
             "properties": {
@@ -336,6 +508,52 @@
               "object"
             ]
           },
+          "title": "Create (Deprecated)"
+        },
+        {
+          "description": "Create a new session.",
+          "href": "/v3/sessions",
+          "method": "POST",
+          "rel": "create",
+          "type": [
+            "object"
+          ],
+          "schema": {
+            "properties": {
+              "channel": {
+                "description": "unique identifier of channel (must be a string)",
+                "example": "12345",
+                "type": [
+                  "string"
+                ]
+              },
+              "num": {
+                "description": "number of log lines to fetch",
+                "default": "100",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "tail": {
+                "description": "if present with any value, start a live tail session",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "example": {
+              "channel_id": "12345",
+              "num": "5"
+            },
+            "required": [
+              "channel"
+            ],
+            "type": [
+              "object"
+            ]
+          },
           "title": "Create"
         },
         {
@@ -390,6 +608,26 @@
         {
           "description": "Create a new token.",
           "href": "/v2/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fidentity)}/tokens",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/token/definitions/name"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Create (Deprecated)"
+        },
+        {
+          "description": "Create a new token.",
+          "href": "/v3/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fchannel)}/tokens",
           "method": "POST",
           "rel": "create",
           "schema": {

--- a/doc/schema/schema.json
+++ b/doc/schema/schema.json
@@ -332,9 +332,6 @@
                 "$ref": "#/definitions/drain/definitions/url"
               }
             },
-            "required": [
-              "url"
-            ],
             "type": [
               "object"
             ]
@@ -521,7 +518,7 @@
           "schema": {
             "properties": {
               "channel": {
-                "description": "unique identifier of channel (must be a string)",
+                "description": "unique identifier of channel",
                 "example": "12345",
                 "type": [
                   "string"

--- a/doc/schema/schema.md
+++ b/doc/schema/schema.md
@@ -1,4 +1,6 @@
-## <a name="resource-channel"></a>Channel
+
+## <a name="resource-channel">Channel</a>
+
 
 A channel is a log stream.
 
@@ -6,12 +8,12 @@ A channel is a log stream.
 
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
-| **drains** | *array* | drains under the channel | `[{"id"=>123456, "token"=>"d.01234567-89ab-cdef-0123-456789abcdef", "url"=>"https://example.org"}]` |
 | **channel** | *string* | unique identifier of a channel | `"123456"` |
 | **channel_id** | *integer* | unique identifier of a channel (deprecated) | `123456` |
-| **tokens** | *array* | tokens under the channel | `[{"token"=>"t.01234567-89ab-cdef-0123-456789abcdef", "name"=>"my-token"}]` |
+| **drains** | *array* | drains under the channel | `[{"id":123456,"token":"d.01234567-89ab-cdef-0123-456789abcdef","url":"https://example.org"}]` |
+| **tokens** | *array* | tokens under the channel | `[{"token":"t.01234567-89ab-cdef-0123-456789abcdef","name":"my-token"}]` |
 
-### Channel Create (Deprecated)
+### <a name="link-POST-channel-/channels">Channel Create (Deprecated)</a>
 
 Create a new channel.
 
@@ -37,15 +39,14 @@ POST /channels
 
 ```bash
 $ curl -n -X POST https://logplex.heroku.com/channels \
-  -H "Content-Type: application/json" \
- \
   -d '{
   "name": "my-channel",
   "tokens": [
     "my-token",
     "your-token"
   ]
-}'
+}' \
+  -H "Content-Type: application/json"
 ```
 
 
@@ -65,7 +66,7 @@ HTTP/1.1 201 Created
 }
 ```
 
-### Channel Delete (Deprecated)
+### <a name="link-DELETE-channel-/v2/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fidentity)}">Channel Delete (Deprecated)</a>
 
 Delete an existing channel.
 
@@ -78,7 +79,7 @@ DELETE /v2/channels/{channel_channel_id}
 
 ```bash
 $ curl -n -X DELETE https://logplex.heroku.com/v2/channels/$CHANNEL_CHANNEL_ID \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json"
 ```
 
 
@@ -92,7 +93,7 @@ HTTP/1.1 200 OK
 
 ```
 
-### Channel Info (Deprecated)
+### <a name="link-GET-channel-/v2/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fidentity)}">Channel Info (Deprecated)</a>
 
 Info for existing channel.
 
@@ -124,7 +125,7 @@ HTTP/1.1 200 OK
 }
 ```
 
-### Channel Create or Update
+### <a name="link-PUT-channel-/v3/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fchannel)}">Channel Create or Update</a>
 
 Create or update a channel.
 
@@ -143,14 +144,13 @@ PUT /v3/channels/{channel_channel}
 
 ```bash
 $ curl -n -X PUT https://logplex.heroku.com/v3/channels/$CHANNEL_CHANNEL \
-  -H "Content-Type: application/json" \
- \
   -d '{
   "tokens": [
     "my-token",
     "your-token"
   ]
-}'
+}' \
+  -H "Content-Type: application/json"
 ```
 
 
@@ -170,7 +170,7 @@ HTTP/1.1 200 OK
 }
 ```
 
-### Channel Info
+### <a name="link-GET-channel-/v3/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fchannel)}">Channel Info</a>
 
 Info for existing channel.
 
@@ -202,7 +202,7 @@ HTTP/1.1 200 OK
 }
 ```
 
-### Channel Delete
+### <a name="link-DELETE-channel-/v3/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fchannel)}">Channel Delete</a>
 
 Delete an existing channel.
 
@@ -215,7 +215,7 @@ DELETE /v3/channels/{channel_channel}
 
 ```bash
 $ curl -n -X DELETE https://logplex.heroku.com/v3/channels/$CHANNEL_CHANNEL \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json"
 ```
 
 
@@ -230,7 +230,8 @@ HTTP/1.1 204 No Content
 ```
 
 
-## <a name="resource-drain"></a>Drain
+## <a name="resource-drain">Drain</a>
+
 
 Drains are log stream tee targets.
 
@@ -242,7 +243,7 @@ Drains are log stream tee targets.
 | **token** | *string* | drain token | `"d.01234567-89ab-cdef-0123-456789abcdef"` |
 | **url** | *string* | drain destination | `"https://example.org"` |
 
-### Drain Create (Deprecated)
+### <a name="link-POST-drain-/v2/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fidentity)}/drains">Drain Create (Deprecated)</a>
 
 Create a new drain.
 
@@ -262,11 +263,10 @@ POST /v2/channels/{channel_channel_id}/drains
 
 ```bash
 $ curl -n -X POST https://logplex.heroku.com/v2/channels/$CHANNEL_CHANNEL_ID/drains \
-  -H "Content-Type: application/json" \
- \
   -d '{
   "url": "https://example.org"
-}'
+}' \
+  -H "Content-Type: application/json"
 ```
 
 
@@ -284,7 +284,7 @@ HTTP/1.1 201 Created
 }
 ```
 
-### Drain Create
+### <a name="link-POST-drain-/v3/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fchannel)}/drains">Drain Create</a>
 
 Create a new drain.
 
@@ -292,23 +292,21 @@ Create a new drain.
 POST /v3/channels/{channel_channel}/drains
 ```
 
-#### Required Parameters
+#### Optional Parameters
 
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
 | **url** | *string* | drain destination | `"https://example.org"` |
 
 
-
 #### Curl Example
 
 ```bash
 $ curl -n -X POST https://logplex.heroku.com/v3/channels/$CHANNEL_CHANNEL/drains \
-  -H "Content-Type: application/json" \
- \
   -d '{
   "url": "https://example.org"
-}'
+}' \
+  -H "Content-Type: application/json"
 ```
 
 
@@ -326,7 +324,7 @@ HTTP/1.1 201 Created
 }
 ```
 
-### Drain Delete (Deprecated)
+### <a name="link-DELETE-drain-/v2/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fidentity)}/drains/{(%23%2Fdefinitions%2Fdrain%2Fdefinitions%2Fidentity)}">Drain Delete (Deprecated)</a>
 
 Delete an existing drain.
 
@@ -339,7 +337,7 @@ DELETE /v2/channels/{channel_channel_id}/drains/{drain_id}
 
 ```bash
 $ curl -n -X DELETE https://logplex.heroku.com/v2/channels/$CHANNEL_CHANNEL_ID/drains/$DRAIN_ID \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json"
 ```
 
 
@@ -353,7 +351,7 @@ HTTP/1.1 200 OK
 
 ```
 
-### Drain Delete
+### <a name="link-DELETE-drain-/v3/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fchannel)}/drains/{(%23%2Fdefinitions%2Fdrain%2Fdefinitions%2Fidentity)}">Drain Delete</a>
 
 Delete an existing drain.
 
@@ -366,7 +364,7 @@ DELETE /v3/channels/{channel_channel}/drains/{drain_id}
 
 ```bash
 $ curl -n -X DELETE https://logplex.heroku.com/v3/channels/$CHANNEL_CHANNEL/drains/$DRAIN_ID \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json"
 ```
 
 
@@ -380,7 +378,7 @@ HTTP/1.1 204 No Content
 
 ```
 
-### Drain Update (Deprecated)
+### <a name="link-POST-drain-/v2/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fidentity)}/drains/{(%23%2Fdefinitions%2Fdrain%2Fdefinitions%2Fidentity)}">Drain Update (Deprecated)</a>
 
 Update an existing drain.
 
@@ -400,11 +398,10 @@ POST /v2/channels/{channel_channel_id}/drains/{drain_id}
 
 ```bash
 $ curl -n -X POST https://logplex.heroku.com/v2/channels/$CHANNEL_CHANNEL_ID/drains/$DRAIN_ID \
-  -H "Content-Type: application/json" \
- \
   -d '{
   "url": "https://example.org"
-}'
+}' \
+  -H "Content-Type: application/json"
 ```
 
 
@@ -422,7 +419,7 @@ HTTP/1.1 200 OK
 }
 ```
 
-### Drain Update
+### <a name="link-PUT-drain-/v3/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fchannel)}/drains/{(%23%2Fdefinitions%2Fdrain%2Fdefinitions%2Fidentity)}">Drain Update</a>
 
 Update an existing drain.
 
@@ -442,11 +439,10 @@ PUT /v3/channels/{channel_channel}/drains/{drain_id}
 
 ```bash
 $ curl -n -X PUT https://logplex.heroku.com/v3/channels/$CHANNEL_CHANNEL/drains/$DRAIN_ID \
-  -H "Content-Type: application/json" \
- \
   -d '{
   "url": "https://example.org"
-}'
+}' \
+  -H "Content-Type: application/json"
 ```
 
 
@@ -465,11 +461,12 @@ HTTP/1.1 200 OK
 ```
 
 
-## <a name="resource-health"></a>Healthchecks
+## <a name="resource-health">Healthchecks</a>
 
 
 
-### Healthchecks 
+
+### <a name="link-GET-health-/healthcheck">Healthchecks </a>
 
 Performs a health check against the API.
 
@@ -498,7 +495,8 @@ HTTP/1.1 200 OK
 ```
 
 
-## <a name="resource-session"></a>Session
+## <a name="resource-session">Session</a>
+
 
 Sessions fetch recent and real-time logs from channels.
 
@@ -508,7 +506,7 @@ Sessions fetch recent and real-time logs from channels.
 | ------- | ------- | ------- | ------- |
 | **url** | *string* | session URL to GET to retrieve logs | `"https://logplex.heroku.com/sessions/d58fb90e-c2bd-4e16-bfe0-e9e7cc7bff7f"` |
 
-### Session Create (Deprecated)
+### <a name="link-POST-session-/v2/sessions">Session Create (Deprecated)</a>
 
 Create a new session.
 
@@ -535,12 +533,11 @@ POST /v2/sessions
 
 ```bash
 $ curl -n -X POST https://logplex.heroku.com/v2/sessions \
-  -H "Content-Type: application/json" \
- \
   -d '{
   "channel_id": "12345",
   "num": "5"
-}'
+}' \
+  -H "Content-Type: application/json"
 ```
 
 
@@ -556,7 +553,7 @@ HTTP/1.1 201 Created
 }
 ```
 
-### Session Create
+### <a name="link-POST-session-/v3/sessions">Session Create</a>
 
 Create a new session.
 
@@ -568,7 +565,7 @@ POST /v3/sessions
 
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
-| **channel** | *string* | unique identifier of channel (must be a string) | `"12345"` |
+| **channel** | *string* | unique identifier of channel | `"12345"` |
 
 
 #### Optional Parameters
@@ -583,12 +580,11 @@ POST /v3/sessions
 
 ```bash
 $ curl -n -X POST https://logplex.heroku.com/v3/sessions \
-  -H "Content-Type: application/json" \
- \
   -d '{
   "channel_id": "12345",
   "num": "5"
-}'
+}' \
+  -H "Content-Type: application/json"
 ```
 
 
@@ -604,7 +600,7 @@ HTTP/1.1 201 Created
 }
 ```
 
-### Session Logs
+### <a name="link-GET-session-/sessions/{(%23%2Fdefinitions%2Fsession%2Fdefinitions%2Fidentity)}">Session Logs</a>
 
 Get the chunk encoded session log data. If tail was specified the connection is long lived.
 
@@ -638,7 +634,8 @@ Transfer-Encoding: chunked
 ```
 
 
-## <a name="resource-token"></a>Token
+## <a name="resource-token">Token</a>
+
 
 Tokens are log producers.
 
@@ -646,10 +643,10 @@ Tokens are log producers.
 
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
-| **token** | *string* | unique identifier of token | `"t.01234567-89ab-cdef-0123-456789abcdef"` |
 | **name** | *string* | name of token | `"my-token"` |
+| **token** | *string* | unique identifier of token | `"t.01234567-89ab-cdef-0123-456789abcdef"` |
 
-### Token Create (Deprecated)
+### <a name="link-POST-token-/v2/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fidentity)}/tokens">Token Create (Deprecated)</a>
 
 Create a new token.
 
@@ -669,11 +666,10 @@ POST /v2/channels/{channel_channel_id}/tokens
 
 ```bash
 $ curl -n -X POST https://logplex.heroku.com/v2/channels/$CHANNEL_CHANNEL_ID/tokens \
-  -H "Content-Type: application/json" \
- \
   -d '{
   "name": "my-token"
-}'
+}' \
+  -H "Content-Type: application/json"
 ```
 
 
@@ -690,7 +686,7 @@ HTTP/1.1 201 Created
 }
 ```
 
-### Token Create
+### <a name="link-POST-token-/v3/channels/{(%23%2Fdefinitions%2Fchannel%2Fdefinitions%2Fchannel)}/tokens">Token Create</a>
 
 Create a new token.
 
@@ -710,11 +706,10 @@ POST /v3/channels/{channel_channel}/tokens
 
 ```bash
 $ curl -n -X POST https://logplex.heroku.com/v3/channels/$CHANNEL_CHANNEL/tokens \
-  -H "Content-Type: application/json" \
- \
   -d '{
   "name": "my-token"
-}'
+}' \
+  -H "Content-Type: application/json"
 ```
 
 

--- a/doc/schema/schema.md
+++ b/doc/schema/schema.md
@@ -7,10 +7,11 @@ A channel is a log stream.
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
 | **drains** | *array* | drains under the channel | `[{"id"=>123456, "token"=>"d.01234567-89ab-cdef-0123-456789abcdef", "url"=>"https://example.org"}]` |
-| **channel_id** | *integer* | unique identifier of channel | `123456` |
+| **channel** | *string* | unique identifier of a channel | `"123456"` |
+| **channel_id** | *integer* | unique identifier of a channel (deprecated) | `123456` |
 | **tokens** | *array* | tokens under the channel | `[{"token"=>"t.01234567-89ab-cdef-0123-456789abcdef", "name"=>"my-token"}]` |
 
-### Channel Create
+### Channel Create (Deprecated)
 
 Create a new channel.
 
@@ -64,7 +65,7 @@ HTTP/1.1 201 Created
 }
 ```
 
-### Channel Delete
+### Channel Delete (Deprecated)
 
 Delete an existing channel.
 
@@ -91,7 +92,7 @@ HTTP/1.1 200 OK
 
 ```
 
-### Channel Info
+### Channel Info (Deprecated)
 
 Info for existing channel.
 
@@ -115,21 +116,117 @@ HTTP/1.1 200 OK
 
 ```json
 {
-  "drains": [
-    {
-      "id": 123456,
-      "token": "d.01234567-89ab-cdef-0123-456789abcdef",
-      "url": "https://example.org"
-    }
-  ],
   "channel_id": 123456,
-  "tokens": [
-    {
-      "token": "t.01234567-89ab-cdef-0123-456789abcdef",
-      "name": "my-token"
-    }
-  ]
+  "tokens": {
+    "my-token": "t.01234567-89ab-cdef-0123-456789abcdef",
+    "your-token": "t.5b432a82-2c03-4ecd-a8d4-a75d627b29ab"
+  }
 }
+```
+
+### Channel Create or Update
+
+Create or update a channel.
+
+```
+PUT /v3/channels/{channel_channel}
+```
+
+#### Optional Parameters
+
+| Name | Type | Description | Example |
+| ------- | ------- | ------- | ------- |
+| **tokens** | *array* | names of tokens to create | `["my-token","your-token"]` |
+
+
+#### Curl Example
+
+```bash
+$ curl -n -X PUT https://logplex.heroku.com/v3/channels/$CHANNEL_CHANNEL \
+  -H "Content-Type: application/json" \
+ \
+  -d '{
+  "tokens": [
+    "my-token",
+    "your-token"
+  ]
+}'
+```
+
+
+#### Response Example
+
+```
+HTTP/1.1 200 OK
+```
+
+```json
+{
+  "channel": "123456",
+  "tokens": {
+    "my-token": "t.01234567-89ab-cdef-0123-456789abcdef",
+    "your-token": "t.5b432a82-2c03-4ecd-a8d4-a75d627b29ab"
+  }
+}
+```
+
+### Channel Info
+
+Info for existing channel.
+
+```
+GET /v3/channels/{channel_channel}
+```
+
+
+#### Curl Example
+
+```bash
+$ curl -n https://logplex.heroku.com/v3/channels/$CHANNEL_CHANNEL
+```
+
+
+#### Response Example
+
+```
+HTTP/1.1 200 OK
+```
+
+```json
+{
+  "channel": "123456",
+  "tokens": {
+    "my-token": "t.01234567-89ab-cdef-0123-456789abcdef",
+    "your-token": "t.5b432a82-2c03-4ecd-a8d4-a75d627b29ab"
+  }
+}
+```
+
+### Channel Delete
+
+Delete an existing channel.
+
+```
+DELETE /v3/channels/{channel_channel}
+```
+
+
+#### Curl Example
+
+```bash
+$ curl -n -X DELETE https://logplex.heroku.com/v3/channels/$CHANNEL_CHANNEL \
+  -H "Content-Type: application/json" \
+```
+
+
+#### Response Example
+
+```
+HTTP/1.1 204 No Content
+```
+
+```json
+
 ```
 
 
@@ -145,7 +242,7 @@ Drains are log stream tee targets.
 | **token** | *string* | drain token | `"d.01234567-89ab-cdef-0123-456789abcdef"` |
 | **url** | *string* | drain destination | `"https://example.org"` |
 
-### Drain Create
+### Drain Create (Deprecated)
 
 Create a new drain.
 
@@ -187,7 +284,49 @@ HTTP/1.1 201 Created
 }
 ```
 
-### Drain Delete
+### Drain Create
+
+Create a new drain.
+
+```
+POST /v3/channels/{channel_channel}/drains
+```
+
+#### Required Parameters
+
+| Name | Type | Description | Example |
+| ------- | ------- | ------- | ------- |
+| **url** | *string* | drain destination | `"https://example.org"` |
+
+
+
+#### Curl Example
+
+```bash
+$ curl -n -X POST https://logplex.heroku.com/v3/channels/$CHANNEL_CHANNEL/drains \
+  -H "Content-Type: application/json" \
+ \
+  -d '{
+  "url": "https://example.org"
+}'
+```
+
+
+#### Response Example
+
+```
+HTTP/1.1 201 Created
+```
+
+```json
+{
+  "id": 123456,
+  "token": "d.01234567-89ab-cdef-0123-456789abcdef",
+  "url": "https://example.org"
+}
+```
+
+### Drain Delete (Deprecated)
 
 Delete an existing drain.
 
@@ -214,7 +353,34 @@ HTTP/1.1 200 OK
 
 ```
 
-### Drain Update
+### Drain Delete
+
+Delete an existing drain.
+
+```
+DELETE /v3/channels/{channel_channel}/drains/{drain_id}
+```
+
+
+#### Curl Example
+
+```bash
+$ curl -n -X DELETE https://logplex.heroku.com/v3/channels/$CHANNEL_CHANNEL/drains/$DRAIN_ID \
+  -H "Content-Type: application/json" \
+```
+
+
+#### Response Example
+
+```
+HTTP/1.1 204 No Content
+```
+
+```json
+
+```
+
+### Drain Update (Deprecated)
 
 Update an existing drain.
 
@@ -234,6 +400,48 @@ POST /v2/channels/{channel_channel_id}/drains/{drain_id}
 
 ```bash
 $ curl -n -X POST https://logplex.heroku.com/v2/channels/$CHANNEL_CHANNEL_ID/drains/$DRAIN_ID \
+  -H "Content-Type: application/json" \
+ \
+  -d '{
+  "url": "https://example.org"
+}'
+```
+
+
+#### Response Example
+
+```
+HTTP/1.1 200 OK
+```
+
+```json
+{
+  "id": 123456,
+  "token": "d.01234567-89ab-cdef-0123-456789abcdef",
+  "url": "https://example.org"
+}
+```
+
+### Drain Update
+
+Update an existing drain.
+
+```
+PUT /v3/channels/{channel_channel}/drains/{drain_id}
+```
+
+#### Required Parameters
+
+| Name | Type | Description | Example |
+| ------- | ------- | ------- | ------- |
+| **url** | *string* | drain destination | `"https://example.org"` |
+
+
+
+#### Curl Example
+
+```bash
+$ curl -n -X PUT https://logplex.heroku.com/v3/channels/$CHANNEL_CHANNEL/drains/$DRAIN_ID \
   -H "Content-Type: application/json" \
  \
   -d '{
@@ -300,7 +508,7 @@ Sessions fetch recent and real-time logs from channels.
 | ------- | ------- | ------- | ------- |
 | **url** | *string* | session URL to GET to retrieve logs | `"https://logplex.heroku.com/sessions/d58fb90e-c2bd-4e16-bfe0-e9e7cc7bff7f"` |
 
-### Session Create
+### Session Create (Deprecated)
 
 Create a new session.
 
@@ -327,6 +535,54 @@ POST /v2/sessions
 
 ```bash
 $ curl -n -X POST https://logplex.heroku.com/v2/sessions \
+  -H "Content-Type: application/json" \
+ \
+  -d '{
+  "channel_id": "12345",
+  "num": "5"
+}'
+```
+
+
+#### Response Example
+
+```
+HTTP/1.1 201 Created
+```
+
+```json
+{
+  "url": "https://logplex.heroku.com/sessions/d58fb90e-c2bd-4e16-bfe0-e9e7cc7bff7f"
+}
+```
+
+### Session Create
+
+Create a new session.
+
+```
+POST /v3/sessions
+```
+
+#### Required Parameters
+
+| Name | Type | Description | Example |
+| ------- | ------- | ------- | ------- |
+| **channel** | *string* | unique identifier of channel (must be a string) | `"12345"` |
+
+
+#### Optional Parameters
+
+| Name | Type | Description | Example |
+| ------- | ------- | ------- | ------- |
+| **num** | *nullable string* | number of log lines to fetch<br/> **default:** `"100"` | `null` |
+| **tail** | *nullable boolean* | if present with any value, start a live tail session | `null` |
+
+
+#### Curl Example
+
+```bash
+$ curl -n -X POST https://logplex.heroku.com/v3/sessions \
   -H "Content-Type: application/json" \
  \
   -d '{
@@ -393,7 +649,7 @@ Tokens are log producers.
 | **token** | *string* | unique identifier of token | `"t.01234567-89ab-cdef-0123-456789abcdef"` |
 | **name** | *string* | name of token | `"my-token"` |
 
-### Token Create
+### Token Create (Deprecated)
 
 Create a new token.
 
@@ -413,6 +669,47 @@ POST /v2/channels/{channel_channel_id}/tokens
 
 ```bash
 $ curl -n -X POST https://logplex.heroku.com/v2/channels/$CHANNEL_CHANNEL_ID/tokens \
+  -H "Content-Type: application/json" \
+ \
+  -d '{
+  "name": "my-token"
+}'
+```
+
+
+#### Response Example
+
+```
+HTTP/1.1 201 Created
+```
+
+```json
+{
+  "token": "t.01234567-89ab-cdef-0123-456789abcdef",
+  "name": "my-token"
+}
+```
+
+### Token Create
+
+Create a new token.
+
+```
+POST /v3/channels/{channel_channel}/tokens
+```
+
+#### Required Parameters
+
+| Name | Type | Description | Example |
+| ------- | ------- | ------- | ------- |
+| **name** | *string* | name of token | `"my-token"` |
+
+
+
+#### Curl Example
+
+```bash
+$ curl -n -X POST https://logplex.heroku.com/v3/channels/$CHANNEL_CHANNEL/tokens \
   -H "Content-Type: application/json" \
  \
   -d '{

--- a/doc/schema/schemata/channel.yaml
+++ b/doc/schema/schemata/channel.yaml
@@ -3,10 +3,15 @@
 title: Channel
 definitions:
   channel_id:
-    description: unique identifier of channel
+    description: unique identifier of a channel (deprecated)
     example: 123456
     type:
       - integer
+  channel:
+    description: unique identifier of a channel
+    example: "123456"
+    type:
+      - string
   drains:
     description: drains under the channel
     items:
@@ -59,26 +64,94 @@ links:
         example: {"my-token": "t.01234567-89ab-cdef-0123-456789abcdef", "your-token":"t.5b432a82-2c03-4ecd-a8d4-a75d627b29ab"}
         type:
           - object
-  title: Create
+  title: Create (Deprecated)
 - description: Delete an existing channel.
   href: "/v2/channels/{(%2Fschemata%2Fchannel%23%2Fdefinitions%2Fidentity)}"
   method: DELETE
   rel: "empty"
   response_example:
     head: "HTTP/1.1 200 OK"
-  title: Delete
+  title: Delete (Deprecated)
   type:
     - null
 - description: Info for existing channel.
   href: "/v2/channels/{(%2Fschemata%2Fchannel%23%2Fdefinitions%2Fidentity)}"
   method: GET
   rel: self
-  title: Info
+  title: Info (Deprecated)
+  targetSchema:
+    type:
+      - object
+    properties:
+      channel_id:
+        "$ref": "/schemata/channel#/definitions/channel_id"
+      tokens:
+        description: created token names and tokens
+        example: {"my-token": "t.01234567-89ab-cdef-0123-456789abcdef", "your-token":"t.5b432a82-2c03-4ecd-a8d4-a75d627b29ab"}
+        type:
+          - object
   type:
     - object
+- description: Create or update a channel.
+  href: "/v3/channels/{(%2Fschemata%2Fchannel%23%2Fdefinitions%2Fchannel)}"
+  method: PUT
+  rel: create_or_update
+  schema:
+    properties:
+      tokens:
+        description: names of tokens to create
+        example:
+          - my-token
+          - your-token
+        items:
+          type:
+            - string
+        type:
+          - array
+    type:
+      - object
+  targetSchema:
+    type:
+      - object
+    properties:
+      channel:
+        "$ref": "/schemata/channel#/definitions/channel"
+      tokens:
+        description: token names and tokens
+        example: {"my-token": "t.01234567-89ab-cdef-0123-456789abcdef", "your-token":"t.5b432a82-2c03-4ecd-a8d4-a75d627b29ab"}
+        type:
+          - object
+  title: Create or Update
+- description: Info for existing channel.
+  href: "/v3/channels/{(%2Fschemata%2Fchannel%23%2Fdefinitions%2Fchannel)}"
+  method: GET
+  rel: self
+  title: Info
+  targetSchema:
+    type:
+      - object
+    properties:
+      channel:
+        "$ref": "/schemata/channel#/definitions/channel"
+      tokens:
+        description: token names and tokens
+        example: {"my-token": "t.01234567-89ab-cdef-0123-456789abcdef", "your-token":"t.5b432a82-2c03-4ecd-a8d4-a75d627b29ab"}
+        type:
+          - object
+- description: Delete an existing channel.
+  href: "/v3/channels/{(%2Fschemata%2Fchannel%23%2Fdefinitions%2Fchannel)}"
+  method: DELETE
+  rel: "empty"
+  response_example:
+    head: "HTTP/1.1 204 No Content"
+  title: Delete
+  type:
+    - null
 properties:
   drains:
     "$ref": "/schemata/channel#/definitions/drains"
+  channel:
+    "$ref": "/schemata/channel#/definitions/channel"
   channel_id:
     "$ref": "/schemata/channel#/definitions/channel_id"
   tokens:

--- a/doc/schema/schemata/drain.yaml
+++ b/doc/schema/schemata/drain.yaml
@@ -52,8 +52,6 @@ links:
     properties:
       url:
         "$ref": "/schemata/drain#/definitions/url"
-    required:
-    - url
     type:
     - object
   title: Create

--- a/doc/schema/schemata/drain.yaml
+++ b/doc/schema/schemata/drain.yaml
@@ -43,6 +43,19 @@ links:
     - url
     type:
     - object
+  title: Create (Deprecated)
+- description: Create a new drain.
+  href: "/v3/channels/{(%2Fschemata%2Fchannel%23%2Fdefinitions%2Fchannel)}/drains"
+  method: POST
+  rel: create
+  schema:
+    properties:
+      url:
+        "$ref": "/schemata/drain#/definitions/url"
+    required:
+    - url
+    type:
+    - object
   title: Create
 - description: Delete an existing drain.
   href: "/v2/channels/{(%2Fschemata%2Fchannel%23%2Fdefinitions%2Fidentity)}/drains/{(%2Fschemata%2Fdrain%23%2Fdefinitions%2Fidentity)}"
@@ -50,12 +63,34 @@ links:
   rel: "empty"
   response_example:
     head: "HTTP/1.1 200 OK"
+  title: Delete (Deprecated)
+  type:
+    - null
+- description: Delete an existing drain.
+  href: "/v3/channels/{(%2Fschemata%2Fchannel%23%2Fdefinitions%2Fchannel)}/drains/{(%2Fschemata%2Fdrain%23%2Fdefinitions%2Fidentity)}"
+  method: DELETE
+  rel: "empty"
+  response_example:
+    head: "HTTP/1.1 204 No Content"
   title: Delete
   type:
     - null
 - description: Update an existing drain.
   href: "/v2/channels/{(%2Fschemata%2Fchannel%23%2Fdefinitions%2Fidentity)}/drains/{(%2Fschemata%2Fdrain%23%2Fdefinitions%2Fidentity)}"
   method: POST
+  rel: update
+  schema:
+    properties:
+      url:
+        "$ref": "/schemata/drain#/definitions/url"
+    required:
+    - url
+    type:
+    - object
+  title: Update (Deprecated)
+- description: Update an existing drain.
+  href: "/v3/channels/{(%2Fschemata%2Fchannel%23%2Fdefinitions%2Fchannel)}/drains/{(%2Fschemata%2Fdrain%23%2Fdefinitions%2Fidentity)}"
+  method: PUT
   rel: update
   schema:
     properties:

--- a/doc/schema/schemata/session.yaml
+++ b/doc/schema/schemata/session.yaml
@@ -47,6 +47,38 @@ links:
       - channel_id
     type:
       - object
+  title: Create (Deprecated)
+- description: Create a new session.
+  href: "/v3/sessions"
+  method: POST
+  rel: create
+  type:
+    - object
+  schema:
+    properties:
+      channel:
+        description: unique identifier of channel
+        example: "12345"
+        type:
+        - string
+      num:
+        description: number of log lines to fetch
+        default: "100"
+        type:
+        - string
+        - "null"
+      tail:
+        description: if present with any value, start a live tail session
+        type:
+        - boolean
+        - "null"
+    example:
+      channel_id: "12345"
+      num: "5"
+    required:
+      - channel
+    type:
+      - object
   title: Create
 - description: Get the chunk encoded session log data. If tail was specified the connection is long lived.
   href: "/sessions/{(%2Fschemata%2Fsession%23%2Fdefinitions%2Fidentity)}"

--- a/doc/schema/schemata/token.yaml
+++ b/doc/schema/schemata/token.yaml
@@ -28,6 +28,19 @@ links:
     - name
     type:
     - object
+  title: Create (Deprecated)
+- description: Create a new token.
+  href: "/v3/channels/{(%2Fschemata%2Fchannel%23%2Fdefinitions%2Fchannel)}/tokens"
+  method: POST
+  rel: create
+  schema:
+    properties:
+      name:
+        "$ref": "/schemata/token#/definitions/name"
+    required:
+    - name
+    type:
+    - object
   title: Create
 properties:
   token:


### PR DESCRIPTION
Proposal for logplex v3 api. Objective is to ensure core-services holds control over channel ids to mitigate race conditions during channel creation. The proposed api aimes to:

* Leave v2 api completely intact
* Deprecate v2
* Add new v3 api endpoints using the new channel identifiers where necessary

See also https://github.com/heroku/cedar-ops/issues/122