### PR TITLE
Simplify v3 healthcheck

### DIFF
--- a/src/logplex_api_v3_healthcheck.erl
+++ b/src/logplex_api_v3_healthcheck.erl
@@ -11,32 +11,13 @@ init(_Transport, Req, _Opts) ->
 
 %% @private
 handle(Req, State) ->
-    try
-        case logplex_api_v3:is_authorized(Req, State) of
-            {true, Req1, State} ->
-                RegisteredMods = [logplex_stats, logplex_tail, logplex_shard, tcp_acceptor],
-                [case whereis(Mod) of
-                     Pid when is_pid(Pid) ->
-                         true = is_process_alive(Pid);
-                     _Other ->
-                         throw(io_lib:format("Process dead: ~p", [Mod]))
-                 end || Mod <- RegisteredMods],
-                Status = list_to_binary(atom_to_list(logplex_app:config(api_status, normal))),
-                Resp = jsx:encode([{<<"status">>, Status}]),
-                Req2 = cowboy_req:set_resp_body(Resp, Req1),
-                Req3 = cowboy_req:set_resp_header(<<"content-type">>, <<"application/json">>, Req2),
-                {ok, Req4} = cowboy_req:reply(200, Req3),
-                logplex_stats:healthcheck(),
-                {ok, Req4, State};
-            {_NotAuthorized, Req1, State} ->
-                {ok, Req2} = cowboy_req:reply(401, Req1),
-                {ok, Req2, State}
-        end
-    catch
-        _Error:_Reason ->
-            {ok, Rq} = cowboy_req:reply(503, Req),
-            {ok, Rq, State}
-    end.
+	{ok, Req1} = case logplex_app:elb_healthcheck() of
+					 healthy ->
+						 cowboy_req:reply(200, [], <<"OK">>, Req);
+					 unhealthy ->
+						 cowboy_req:reply(503, [], <<"SYSTEM BOOTING">>, Req)
+				 end,
+	{ok, Req1, State}.
 
 %% @private
 terminate(_Reason, _Req, _State) ->


### PR DESCRIPTION
Code for the healtcheck was adapted from an unused part of the old API. Now uses the same pattern for the v3 API as the logs API.

cc @voidlock 