### PR TITLE
Implement sessions endpoint

### DIFF
--- a/doc/schema/schema.json
+++ b/doc/schema/schema.json
@@ -505,6 +505,52 @@
               "object"
             ]
           },
+          "title": "Create (Deprecated)"
+        },
+        {
+          "description": "Create a new session.",
+          "href": "/v3/sessions",
+          "method": "POST",
+          "rel": "create",
+          "type": [
+            "object"
+          ],
+          "schema": {
+            "properties": {
+              "channel_id": {
+                "description": "unique identifier of channel",
+                "example": "d23d5262-d1f0-46f0-93c5-3781b48a258d",
+                "type": [
+                  "string"
+                ]
+              },
+              "num": {
+                "description": "number of log lines to fetch",
+                "default": "100",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "tail": {
+                "description": "if present with any value, start a live tail session",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "example": {
+              "channel_id": "d23d5262-d1f0-46f0-93c5-3781b48a258d",
+              "num": "5"
+            },
+            "required": [
+              "channel_id"
+            ],
+            "type": [
+              "object"
+            ]
+          },
           "title": "Create"
         },
         {

--- a/doc/schema/schema.json
+++ b/doc/schema/schema.json
@@ -519,7 +519,7 @@
             "properties": {
               "channel_id": {
                 "description": "unique identifier of channel",
-                "example": "d23d5262-d1f0-46f0-93c5-3781b48a258d",
+                "example": "app-d23d5262-d1f0-46f0-93c5-3781b48a258d",
                 "type": [
                   "string"
                 ]
@@ -541,7 +541,7 @@
               }
             },
             "example": {
-              "channel_id": "d23d5262-d1f0-46f0-93c5-3781b48a258d",
+              "channel_id": "app-d23d5262-d1f0-46f0-93c5-3781b48a258d",
               "num": "5"
             },
             "required": [

--- a/doc/schema/schema.md
+++ b/doc/schema/schema.md
@@ -565,7 +565,7 @@ POST /v3/sessions
 
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
-| **channel_id** | *string* | unique identifier of channel | `"d23d5262-d1f0-46f0-93c5-3781b48a258d"` |
+| **channel_id** | *string* | unique identifier of channel | `"app-d23d5262-d1f0-46f0-93c5-3781b48a258d"` |
 
 
 #### Optional Parameters
@@ -581,7 +581,7 @@ POST /v3/sessions
 ```bash
 $ curl -n -X POST https://logplex.heroku.com/v3/sessions \
   -d '{
-  "channel_id": "d23d5262-d1f0-46f0-93c5-3781b48a258d",
+  "channel_id": "app-d23d5262-d1f0-46f0-93c5-3781b48a258d",
   "num": "5"
 }' \
   -H "Content-Type: application/json"

--- a/doc/schema/schema.md
+++ b/doc/schema/schema.md
@@ -506,7 +506,7 @@ Sessions fetch recent and real-time logs from channels.
 | ------- | ------- | ------- | ------- |
 | **url** | *string* | session URL to GET to retrieve logs | `"https://logplex.heroku.com/sessions/d58fb90e-c2bd-4e16-bfe0-e9e7cc7bff7f"` |
 
-### <a name="link-POST-session-/v2/sessions">Session Create</a>
+### <a name="link-POST-session-/v2/sessions">Session Create (Deprecated)</a>
 
 Create a new session.
 
@@ -535,6 +535,53 @@ POST /v2/sessions
 $ curl -n -X POST https://logplex.heroku.com/v2/sessions \
   -d '{
   "channel_id": "12345",
+  "num": "5"
+}' \
+  -H "Content-Type: application/json"
+```
+
+
+#### Response Example
+
+```
+HTTP/1.1 201 Created
+```
+
+```json
+{
+  "url": "https://logplex.heroku.com/sessions/d58fb90e-c2bd-4e16-bfe0-e9e7cc7bff7f"
+}
+```
+
+### <a name="link-POST-session-/v3/sessions">Session Create</a>
+
+Create a new session.
+
+```
+POST /v3/sessions
+```
+
+#### Required Parameters
+
+| Name | Type | Description | Example |
+| ------- | ------- | ------- | ------- |
+| **channel_id** | *string* | unique identifier of channel | `"d23d5262-d1f0-46f0-93c5-3781b48a258d"` |
+
+
+#### Optional Parameters
+
+| Name | Type | Description | Example |
+| ------- | ------- | ------- | ------- |
+| **num** | *nullable string* | number of log lines to fetch<br/> **default:** `"100"` | `null` |
+| **tail** | *nullable boolean* | if present with any value, start a live tail session | `null` |
+
+
+#### Curl Example
+
+```bash
+$ curl -n -X POST https://logplex.heroku.com/v3/sessions \
+  -d '{
+  "channel_id": "d23d5262-d1f0-46f0-93c5-3781b48a258d",
   "num": "5"
 }' \
   -H "Content-Type: application/json"

--- a/doc/schema/schemata/session.yaml
+++ b/doc/schema/schemata/session.yaml
@@ -47,6 +47,38 @@ links:
       - channel_id
     type:
       - object
+  title: Create (Deprecated)
+- description: Create a new session.
+  href: "/v3/sessions"
+  method: POST
+  rel: create
+  type:
+    - object
+  schema:
+    properties:
+      channel_id:
+        description: unique identifier of channel
+        example: "d23d5262-d1f0-46f0-93c5-3781b48a258d"
+        type:
+        - string
+      num:
+        description: number of log lines to fetch
+        default: "100"
+        type:
+        - string
+        - "null"
+      tail:
+        description: if present with any value, start a live tail session
+        type:
+        - boolean
+        - "null"
+    example:
+      channel_id: "d23d5262-d1f0-46f0-93c5-3781b48a258d"
+      num: "5"
+    required:
+      - channel_id
+    type:
+      - object
   title: Create
 - description: Get the chunk encoded session log data. If tail was specified the connection is long lived.
   href: "/sessions/{(%2Fschemata%2Fsession%23%2Fdefinitions%2Fidentity)}"

--- a/doc/schema/schemata/session.yaml
+++ b/doc/schema/schemata/session.yaml
@@ -58,7 +58,7 @@ links:
     properties:
       channel_id:
         description: unique identifier of channel
-        example: "d23d5262-d1f0-46f0-93c5-3781b48a258d"
+        example: "app-d23d5262-d1f0-46f0-93c5-3781b48a258d"
         type:
         - string
       num:
@@ -73,7 +73,7 @@ links:
         - boolean
         - "null"
     example:
-      channel_id: "d23d5262-d1f0-46f0-93c5-3781b48a258d"
+      channel_id: "app-d23d5262-d1f0-46f0-93c5-3781b48a258d"
       num: "5"
     required:
       - channel_id

--- a/src/logplex_api_v3_sessions.erl
+++ b/src/logplex_api_v3_sessions.erl
@@ -1,0 +1,102 @@
+-module(logplex_api_v3_sessions).
+
+-include("logplex.hrl").
+-include("logplex_logging.hrl").
+
+-export([init/3,
+         rest_init/2,
+         service_available/2,
+         allowed_methods/2,
+         malformed_request/2,
+         is_authorized/2,
+         resource_exists/2,
+         content_types_accepted/2,
+         from_json/2,
+         content_types_provided/2,
+         to_json/2
+        ]).
+
+-record(state, {
+          channel_id :: undefined | binary()
+         }).
+
+%% @private
+init(_Transport, Req, Opts) ->
+    Route = proplists:get_value(route, Opts),
+    Req1 = logplex_api_v3:prepare(Route, Req),
+    {upgrade, protocol, cowboy_rest, Req1, Opts}.
+
+%% @private
+rest_init(Req, _Opts) ->
+    State = #state{},
+    {ok, Req, State}.
+
+%% @private
+service_available(Req, State) ->
+    logplex_api_v3:service_available(Req, State).
+
+%% @private
+allowed_methods(Req, State) ->
+    {[<<"POST">>], Req, State}.
+
+%% @private
+is_authorized(Req, State) ->
+    logplex_api_v3:is_authorized(Req, State).
+
+%% @private
+resource_exists(Req, State) ->
+    %% We return false here as we are creating a new resource
+    {false, Req, State}.
+
+%% @private
+malformed_request(Req, State) ->
+    {ok, Body, Req1} = cowboy_req:body(Req),
+    try jsx:decode(Body, [return_maps]) of
+        Map ->
+            case validate_payload(Map) of
+                {ok, ChannelId} ->
+                    NewState = State#state{ channel_id = ChannelId },
+                    {false, Req1, NewState};
+                {error, _Reason} ->
+                    {true, Req1, State}
+            end
+    catch
+        error:badarg ->
+            %% invalid json
+            {true, Req1, State}
+    end.
+
+%% @private
+content_types_provided(Req, State) ->
+    {[{{<<"application">>, <<"json">>, []}, to_json}], Req, State}.
+
+%% @private
+content_types_accepted(Req, State) ->
+    {[{{<<"application">>, <<"json">>, []}, from_json}], Req, State}.
+
+%% @private
+to_json(_, _) ->
+    %% function is ignored
+    {error, not_implemented}.
+
+%% @private
+from_json(Req, #state{ channel_id = ChannelId } = State) ->
+    case logplex_channel:find(ChannelId) of
+        {ok, _Channel} ->
+            {ok, Body, Req1} = cowboy_req:body(Req),
+            UUID = logplex_session:publish(Body),
+            Location = iolist_to_binary([logplex_app:config(api_endpoint_url, ""), <<"/sessions/">>, UUID]),
+            Resp = jsx:encode([{<<"url">>, Location}]),
+            Req2 = cowboy_req:set_resp_body(Resp, Req1),
+            {{true, Location}, Req2, State};
+        {error, not_found} ->
+            Resp = jsx:encode([{<<"error">>, <<"channel not found">>}]),
+            Req1 = cowboy_req:set_resp_body(Resp, Req),
+            {ok, Req2} = cowboy_req:reply(422, Req1),
+            {halt, Req2, State}
+    end.
+
+validate_payload(#{ <<"channel_id">> := ChannelId }) when is_binary(ChannelId) ->
+    {ok, ChannelId};
+validate_payload(_) ->
+    {error, invalid_payload}.

--- a/test/logplex_api_v3_SUITE.erl
+++ b/test/logplex_api_v3_SUITE.erl
@@ -7,6 +7,7 @@ all() ->
     [{group, channels}
      , {group, drains}
      , {group, tokens}
+     , {group, sessions}
      , {group, healthcheck}
     ].
 
@@ -46,6 +47,10 @@ groups() ->
        , create_new_token
        , cannot_create_token_without_name
        , cannot_create_token_for_non_existing_channel
+      ]},
+     {sessions,
+      [create_session_for_existing_channel
+       , cannot_create_session_for_non_existing_channel
       ]},
      {healthcheck,
       [healthy,
@@ -516,6 +521,37 @@ cannot_create_token_for_non_existing_channel(Config) ->
     Config.
 
 %% -----------------------------------------------------------------------------
+%% sessions
+%% -----------------------------------------------------------------------------
+
+create_session_for_existing_channel(Config0) ->
+    Config = create_channel_with_tokens(Config0),
+    Channel = ?config(channel, Config),
+    Props = create_session(Channel, Config),
+    Body = proplists:get_value(body, Props),
+    Headers = proplists:get_value(headers, Props),
+    Resp = jsx:decode(list_to_binary(Body), [return_maps]),
+    URL = maps:get(<<"url">>, Resp),
+    Location = proplists:get_value("location", Headers),
+    ?assertEqual(201, proplists:get_value(status_code, Props)),
+    ?assertEqual("Created", proplists:get_value(http_reason, Props)),
+    ?assertEqual("application/json", proplists:get_value("content-type", Headers)),
+    ?assert(is_list(proplists:get_value("request-id", Headers))),
+    ?assert(is_list(Location)),
+    ?assertEqual(Location, binary_to_list(URL)),
+    Config.
+
+cannot_create_session_for_non_existing_channel(Config) ->
+    FakeChannel = new_channel(),
+    Props = create_session(FakeChannel, Config),
+    Headers = proplists:get_value(headers, Props),
+    ?assertEqual(422, proplists:get_value(status_code, Props)),
+    ?assertEqual("Unprocessable Entity", proplists:get_value(http_reason, Props)),
+    ?assert(is_list(proplists:get_value("request-id", Headers))),
+    Config.
+
+
+%% -----------------------------------------------------------------------------
 %% healtchecks
 %% -----------------------------------------------------------------------------
 
@@ -581,6 +617,13 @@ create_token(Channel, TokenName, Config) ->
     Url = ?config(api_v3_url, Config) ++ "/v3/channels/" ++ Channel ++ "/tokens",
     Headers = [{"Authorization", ?config(auth, Config)}],
     JSON = jsx:encode(maps:from_list([{<<"name">>, list_to_binary(TokenName)} || TokenName =/= undefined])),
+    Opts = [{headers, Headers}, {body, JSON}, {timeout, timer:seconds(10)}],
+    logplex_api_SUITE:post(Url, Opts).
+
+create_session(Channel, Config) ->
+    Url = ?config(api_v3_url, Config) ++ "/v3/sessions",
+    Headers = [{"Authorization", ?config(auth, Config)}],
+    JSON = jsx:encode(maps:from_list([{<<"channel_id">>, list_to_binary(Channel)} || Channel =/= undefined])),
     Opts = [{headers, Headers}, {body, JSON}, {timeout, timer:seconds(10)}],
     logplex_api_SUITE:post(Url, Opts).
 


### PR DESCRIPTION
For consistency we implement the v3 API sessions endpoint which is equivalent to the v2 version. 

One minor difference between v3 and v2 is that the channel for which the session is created must exist, otherwise we return a `422 Unprocessable Entity`.