### PR TITLE
Require API URLs

### DIFF
--- a/src/logplex.app.src
+++ b/src/logplex.app.src
@@ -32,7 +32,8 @@
   {mod, {logplex_app, []}},
   {env,
    [
-     {logging_syslog_tab, syslog_tab}
+     {api_endpoint_url, "http://localhost:8001"}
+    ,{logging_syslog_tab, syslog_tab}
     ,{logging_syslog_host, {127, 0, 0, 1}}
     ,{logging_syslog_port, 601}
     ,{logging_syslog_facility, local3}

--- a/src/logplex_app.erl
+++ b/src/logplex_app.erl
@@ -120,8 +120,8 @@ cache_os_envvars() ->
                       ,{force_gc_memory, ["LOGPLEX_FORCE_GC_MEMORY"],
                         optional, %% in bytes
                         integer}
-                      ,{api_endpoint_url, ["LOGPLEX_API_ENDPOINT_URL"],
-                       optional}
+                      ,{api_endpoint_url, ["LOGPLEX_API_ENDPOINT_URL"]}
+                      ,{http_v3_url, ["LOGPLEX_HTTP_V3_URL"]}
                       ,{tls_mode, ["LOGPLEX_TLS_MODE"],
                         optional,
                         atom}

--- a/src/logplex_logs_rest.erl
+++ b/src/logplex_logs_rest.erl
@@ -43,29 +43,11 @@ child_spec() ->
 dispatch() ->
     cowboy_router:compile([{'_',
                             [{<<"/healthcheck">>, ?MODULE, [healthcheck]},
-                             {<<"/logs">>, ?MODULE, [logs]},
-                             % support for v2 API
-                             {<<"/v2/[...]">>, ?MODULE, [api]},
-                             % support for old v1 API
-                             {<<"/channels/[...]">>, ?MODULE, [api]},
-                             {<<"/sessions/[...]">>, ?MODULE, [api]}]}]).
+                             {<<"/logs">>, ?MODULE, [logs]}
+                            ]}]).
 
 init(_Transport, Req, [healthcheck]) ->
     {ok, Req, undefined};
-init(_Transport, Req0, [api]) ->
-    {ok, Req} = case logplex_app:config(api_endpoint_url, undefined) of
-                     undefined ->
-                         cowboy_req:reply(404, [], "", Req0);
-                     Endpoint ->
-                        {Path, Req1} = cowboy_req:path(Req0),
-                        {Query, Req2} = cowboy_req:qs(Req1),
-                        ?INFO("at=api_redirect path=~p query=~p", [Path, Query]),
-                        cowboy_req:reply(302,
-                                         [{<<"Location">>, [Endpoint, Path,
-                                                            "?", Query]}],
-                                         "redirecting", Req2)
-                 end,
-    {shutdown, Req, no_state};
 init(_Transport, _Req, [logs]) ->
     {upgrade, protocol, cowboy_rest}.
 

--- a/test/logplex_api_v3_SUITE.erl
+++ b/test/logplex_api_v3_SUITE.erl
@@ -336,7 +336,7 @@ reserve_drain_without_drainurl(Config0) ->
     ?assertEqual("Created", proplists:get_value(http_reason, Props)),
     ?assertEqual("application/json", proplists:get_value("content-type", Headers)),
     ?assert(is_list(proplists:get_value("request-id", Headers))),
-    ?assert(is_list(proplists:get_value("location", Headers))),
+    ?assertMatch("http://localhost:8002/v3/channels/"++_, proplists:get_value("location", Headers)),
     [{drain, {DrainId, DrainToken, undefined}}
      | Config].
 
@@ -357,7 +357,7 @@ reserve_drain_with_drainurl(Config0) ->
     ?assertEqual("Created", proplists:get_value(http_reason, Props)),
     ?assertEqual("application/json", proplists:get_value("content-type", Headers)),
     ?assert(is_list(proplists:get_value("request-id", Headers))),
-    ?assert(is_list(proplists:get_value("location", Headers))),
+    ?assertMatch("http://localhost:8002/v3/channels/"++_, proplists:get_value("location", Headers)),
     [{drain, {DrainId, DrainToken, DrainUrl}}
      | Config].
 
@@ -561,7 +561,7 @@ create_session_for_existing_channel(Config0) ->
     ?assertEqual("Created", proplists:get_value(http_reason, Props)),
     ?assertEqual("application/json", proplists:get_value("content-type", Headers)),
     ?assert(is_list(proplists:get_value("request-id", Headers))),
-    ?assert(is_list(Location)),
+    ?assertMatch("http://localhost:8001/sessions/"++_, Location), %% note: old api URL
     ?assertEqual(Location, binary_to_list(URL)),
     Config.
 

--- a/test/logplex_logs_rest_SUITE.erl
+++ b/test/logplex_logs_rest_SUITE.erl
@@ -9,8 +9,7 @@
 
 
 all() ->
-    [v2_redirects, v1_redirects_channels, v1_redirects_sessions,
-     post_logline, post_logline_compressed].
+    [post_logline, post_logline_compressed].
 
 init_per_suite(Config) ->
     set_os_vars(),
@@ -22,10 +21,7 @@ end_per_suite(_Config) ->
     application:stop(logplex).
 
 init_per_testcase(Case, Config)
-  when Case =:= v2_redirects;
-       Case =:= v1_redirects_channels;
-       Case =:= v1_redirects_sessions;
-       Case =:= post_logline;
+  when        Case =:= post_logline;
        Case =:= post_logline_compressed ->
     Channel = logplex_channel:create(atom_to_binary(Case, latin1)),
     ChannelId = logplex_channel:id(Channel),
@@ -52,38 +48,6 @@ end_per_testcase(Case, Config)
     Config;
 end_per_testcase(_Case, Config) ->
     Config.
-
-v2_redirects(Config) ->
-    BasicAuth = ?config(auth, Config),
-    Logs = ?config(logs, Config) ++ "/v2/channels/",
-    ChannelId = ?config(channel_id, Config),
-    Get = Logs ++ binary_to_list(ChannelId),
-    %% Get = ?config(logs, Config) ++ "/healthcheck",
-    Res = logplex_api_SUITE:get_(Get, [{headers, [{"Authorization", BasicAuth}]},
-                                       {http_opts, [{autoredirect, false}]}]),
-    302 = proplists:get_value(status_code, Res),
-    ok.
-
-v1_redirects_channels(Config) ->
-    BasicAuth = ?config(auth, Config),
-    ChannelId = ?config(channel_id, Config),
-    Get = binary_to_list(iolist_to_binary([?config(logs, Config),
-           "/channels/",
-           binary_to_list(ChannelId),
-           "/info"])),
-    Res = logplex_api_SUITE:get_(Get, [{headers, [{"Authorization", BasicAuth}]},
-                                       {http_opts, [{autoredirect, false}]}]),
-    302 = proplists:get_value(status_code, Res),
-    ok.
-
-v1_redirects_sessions(Config) ->
-    BasicAuth = ?config(auth, Config),
-    Post = binary_to_list(iolist_to_binary([?config(logs, Config),
-           "/sessions/"])),
-    PostRes = logplex_api_SUITE:post(Post, [{headers, [{"Authorization", BasicAuth}]},
-                                            {http_opts, [{autoredirect, false}]}]),
-    302 = proplists:get_value(status_code, PostRes),
-    ok.
 
 post_logline(Config) ->
     BasicAuth = ?config(auth, Config),


### PR DESCRIPTION
 	

We need to ensure the API URLs for v2 and v3 API are configured. The v3
API requires them in order to redirect a client with a full URL. The v2 API
would return only a path without a hostname. Note this may change how a client
handles redirects.

The new default sets them to:

* v2: `http://localhost:8001`
* v3: `http://localhost:8002`

The environment variables `LOGPLEX_API_ENDPOINT_URL` and
`LOGPLEX_HTTP_V3_URL` are now required to be set, otherwise the above
mentioned defaults are returned.