### PR TITLE
[WIP] Improve lookup drain by channel

### DIFF
--- a/src/logplex.app.src
+++ b/src/logplex.app.src
@@ -40,7 +40,7 @@
     ,{availability_zone, "not-aws"}
     ,{cloud_name, "development"}
     ,{config_redis_url, "redis://localhost:6379"}
-    ,{default_redis_poll_ms, 2000} % #ms
+    ,{default_redis_poll_ms, 5000} % #ms
     ,{drain_buffer_size, 1024} % #messages
     ,{ets_token_reindex_step_size,
       10000} % num tokens per tab read, index write.

--- a/src/logplex_api_v3_drains.erl
+++ b/src/logplex_api_v3_drains.erl
@@ -103,7 +103,6 @@ resource_exists(Req, #state{ channel_id = ChannelId,
     end;
 resource_exists(Req, #state{ channel_id = ChannelId,
                              drain_id   = DrainId } = State) ->
-
     case logplex_channel:find(ChannelId) of
         {ok, _Channel} ->
             case logplex_drain:find(DrainId) of

--- a/src/logplex_drain.erl
+++ b/src/logplex_drain.erl
@@ -45,6 +45,8 @@
          ,find/1
          ,store_token/3
          ,create_ets_table/0
+         ,load/1
+         ,unload/1
         ]).
 
 -export([new/5
@@ -168,6 +170,18 @@ stop(DrainId, Timeout) ->
             supervisor:delete_child(logplex_drain_sup, DrainId);
         _ -> ok
     end.
+
+%% @doc Load drain in local memory.
+-spec load(drain()) -> ok.
+load(Drain) when is_record(Drain, drain) ->
+    true = ets:insert(?DRAINS_TABLE, Drain),
+    ok.
+
+%% @doc Unload drain from local memory.
+-spec unload(id()) -> ok.
+unload(ID) when is_integer(ID) ->
+    true = ets:delete(?DRAINS_TABLE, ID),
+    ok.
 
 reserve_token() ->
     Token = new_token(),

--- a/src/nsync_callback.erl
+++ b/src/nsync_callback.erl
@@ -111,7 +111,7 @@ handle({cmd, "del", [<<"drain:", Suffix/binary>> | Args]}) ->
     Id = drain_id(parse_id(Suffix)),
     ?INFO("at=delete type=drain id=~p", [Id]),
     catch logplex_drain:stop(Id),
-    ets:delete(drains, Id),
+    logplex_drain:unload(Id),
     handle({cmd, "del", Args});
 handle({cmd, "del", [<<"cred:", Suffix/binary>> | Args]}) ->
     Id = logplex_cred:binary_to_id(parse_id(Suffix)),
@@ -234,7 +234,7 @@ create_or_update_drain(Id, Dict) ->
                                 {valid, Type, NewUri} ->
                                     Drain = logplex_drain:new(Id, Ch, Token,
                                                               Type, NewUri),
-                                    ets:insert(drains, Drain),
+                                    ok = logplex_drain:load(Drain),
                                     maybe_update_drain(logplex_drain:start(Drain), Drain),
                                     Drain;
                                 {error, Reason} ->

--- a/test/logplex_api_SUITE.erl
+++ b/test/logplex_api_SUITE.erl
@@ -236,7 +236,7 @@ put_(Url, Opts) ->
 
 request(Method, Url, Opts) ->
     Headers = proplists:get_value(headers, Opts, []),
-    Timeout = proplists:get_value(timeout, Opts, 1000),
+    Timeout = proplists:get_value(timeout, Opts, timer:seconds(2)),
     Request =
         case Method of
             PostOrPut when PostOrPut == post; PostOrPut == put ->
@@ -262,7 +262,7 @@ request(Method, Url, Opts) ->
             {Headers0, Body} = wait_for_http(ReqId, [], []),
             [{headers, Headers0},
              {body, Body}];
-        Other -> ct:pal("~p", [Other]),
+        Other -> ct:pal("HTTP request: ~p ~p ~p failed with reason: ~p", [Method, Url, Opts, Other]),
                  exit(bad_case)
     end.
 


### PR DESCRIPTION
## Reasons to making this change

The performance of drain lookups by channel was worse in the v3 API compared to v2. The performance degradation was caused by changing the key type from integer to binary. This was due to a full table scan in `logplex_drain:lookup_by_channel` calls.
 
## Description of the change
This change improves the lookup performance by introducing a lookup table for drains by channel id.

Furthermore, the v3 API tests run now in parallel.
