### PR TITLE
Get docker-compose working locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ RUN cd /usr/src \
       && cd .. \
       && rm -rf rebar3
 
+RUN mkdir -p /home/logplex
+COPY logplex.env /home/logplex/keys.sh
+
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ RUN cd /usr/src \
       && cd .. \
       && rm -rf rebar3
 
-RUN mkdir -p /home/logplex
-COPY logplex.env /home/logplex/keys.sh
+RUN mkdir -p /home/logplex && ln -s logplex.env /home/logplex/keys.sh
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Prior versions of Logplex are designed to run on R16B03 and 17.x.
 ### build
 
     $ ./rebar3 as public compile
-    
+
 ### develop
 
 run
@@ -94,16 +94,17 @@ Runs the common test suite for logplex.
 ### develop
 
 Requires a working install of Docker and Docker Compose.
-Follow the [installations](https://docs.docker.com/installation/#installation)
-steps outlined docs.docker.com.
+Follow the [installation steps](https://docs.docker.com/installation/#installation)
+outlined on the Docker website.
 ```
+source setup-host-vars.sh    # create network related env vars
+
 docker-compose build         # Run once
 docker-compose run compile   # Run everytime source files change
 docker-compose up logplex    # Run logplex post-compilation
 ```
 
 To connect to the above logplex Erlang shell:
-
 ```
 docker exec -it logplex_logplex_1 bash -c "TERM=xterm bin/connect"
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,10 +25,10 @@ clean:
 logplex:
   image: logplex_base
   command: ./_build/default/rel/logplex/bin/logplex foreground
-  hostname: logplex
-  domainname: docker.local
+  hostname: $LOGPLEX_HOSTNAME
+  domainname: $LOGPLEX_DOMAIN_NAME
   environment:
-    - INSTANCE_NAME=logplex.docker.local
+    - INSTANCE_NAME=$LOGPLEX_INSTANCE_NAME
     - LOCAL_IP=127.0.0.1
   env_file:
     - logplex.env
@@ -81,4 +81,3 @@ test_bash:
     - base
   links:
     - db
-

--- a/setup-host-vars.sh
+++ b/setup-host-vars.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+FQHN=$(hostname -f)
+DN=${FQHN#*.*}
+
+export LOGPLEX_HOSTNAME=logplex
+echo "The logplex hostname        $LOGPLEX_HOSTNAME"
+
+export LOGPLEX_DOMAIN_NAME=$LOGPLEX_HOSTNAME.$DN
+echo "The logplex FQ domain name  $LOGPLEX_DOMAIN_NAME"
+
+export LOGPLEX_INSTANCE_NAME=$LOGPLEX_HOSTNAME@$LOGPLEX_DOMAIN_NAME
+echo "The logplex instance name   $LOGPLEX_INSTANCE_NAME"


### PR DESCRIPTION
As a newcomer to the logplex project, I attempted to get the Docker based dev environment up and running. I ran into two issues while attempting to follow the README:

First, when I initially tried to initiate a remote connection to the logplex container, it failed due to a missing file called `keys.sh`. According to another engineer, the contents of this file were similar/same as the `logplex.env` file. I updated the dockerfile to symlink `logplex.env` --> `keys.sh`.

Second, I discovered that erlang is very particular wrt how host/nodes are named. The values for the `domainname` attrib and `instance name` env var in the `docker-compose.yml` file didn’t match up with the running logplex container. I replaced these two values and the `hostname` attribute in the `docker-compose.yml` file with environment variable references, and added a small shell script that sets these variables before the container is built. See the README changes.