### PR TITLE
 make http log input acceptors and max connections tunable

### DIFF
--- a/src/logplex.app.src
+++ b/src/logplex.app.src
@@ -49,6 +49,8 @@
     ,{http_drain_target_bytes, 102400} % bytes
     ,{http_frame_retries, 2} % #extra attempts after first
     ,{http_log_input_port, 8601} % syslog/http tcp listen port
+    ,{http_log_input_acceptors, 100}
+    ,{http_log_input_max_connections, 1024}
     ,{http_port, 8001}
     ,{http_v3_url, "http://localhost:8002"}
     ,{http_v3_port, 8002}

--- a/src/logplex_app.erl
+++ b/src/logplex_app.erl
@@ -132,6 +132,12 @@ cache_os_envvars() ->
                       ,{tls_pinned_certs, ["LOGPLEX_TLS_PINNED_CERTS"],
                         optional,
                         binary}
+                     ,{http_log_input_acceptors, ["HTTP_LOG_INPUT_ACCEPTORS"],
+                       optional,
+                       integer}
+                     ,{http_log_input_max_connections, ["HTTP_LOG_INPUT_MAX_CONNECTIONS"],
+                       optional,
+                       integer}
                      ]),
     ok.
 

--- a/src/logplex_logs_rest.erl
+++ b/src/logplex_logs_rest.erl
@@ -33,9 +33,10 @@
 -define(BASIC_AUTH, <<"Basic realm=Logplex">>).
 
 child_spec() ->
-    ranch:child_spec(?MODULE, 100,
+    ranch:child_spec(?MODULE, logplex_app:config(http_log_input_acceptors),
                      ranch_tcp,
-                     [{port, logplex_app:config(http_log_input_port)}],
+                     [{port, logplex_app:config(http_log_input_port)},
+                      {max_connections, logplex_app:config(http_log_input_max_connections)}],
                      cowboy_protocol,
                      [{env,
                        [{dispatch, dispatch()}]}]).


### PR DESCRIPTION
For https://salesforce.quip.com/LHvNARc4cIJ4

It seems like we are hitting either the acceptor pool size of 100 or the default ranch max connections limit of 1024. Make them tunable, defaulting to their current values, so we can verify.