### PR TITLE
Add control rod to deny creation of tail sessions

### DIFF
--- a/src/logplex_api_v3_sessions.erl
+++ b/src/logplex_api_v3_sessions.erl
@@ -34,7 +34,12 @@ rest_init(Req, _Opts) ->
 
 %% @private
 service_available(Req, State) ->
-    logplex_api_v3:service_available(Req, State).
+    case logplex_app:config(deny_tail_sessions, false) of
+        true ->
+            {false, Req, State};
+        _ ->
+            logplex_api_v3:service_available(Req, State)
+    end.
 
 %% @private
 allowed_methods(Req, State) ->

--- a/src/logplex_app.erl
+++ b/src/logplex_app.erl
@@ -138,6 +138,9 @@ cache_os_envvars() ->
                      ,{http_log_input_max_connections, ["HTTP_LOG_INPUT_MAX_CONNECTIONS"],
                        optional,
                        integer}
+                     ,{deny_tail_sessions, ["DENY_TAIL_SESSIONS"],
+                       optional,
+                       atom}
                      ]),
     ok.
 


### PR DESCRIPTION
New environment variable `DENY_TAIL_SESSIONS` allows to block creation
of tail sessions.