### PR TITLE
Add control rod to deny redis buffers

### DIFF
--- a/src/logplex_app.erl
+++ b/src/logplex_app.erl
@@ -141,6 +141,9 @@ cache_os_envvars() ->
                      ,{deny_tail_sessions, ["DENY_TAIL_SESSIONS"],
                        optional,
                        atom}
+                     ,{deny_redis_buffers, ["DENY_REDIS_BUFFERS"],
+                       optional,
+                       atom}
                      ]),
     ok.
 

--- a/src/logplex_message.erl
+++ b/src/logplex_message.erl
@@ -80,7 +80,7 @@ process_msg(RawMsg, ChannelId, Token, TokenName, ShardInfo)
             logplex_firehose:post_msg(ChannelId, TokenName, RawMsg),
             process_drains(ChannelId, CookedMsg),
             process_tails(ChannelId, CookedMsg),
-            process_redis(ChannelId, ShardInfo, CookedMsg, Flag)
+            process_redis(ChannelId, ShardInfo, CookedMsg, logplex_app:config(deny_redis_buffers, Flag))
     end.
 
 process_error(ChannelID, Origin, ?L14, Fmt, Args) ->


### PR DESCRIPTION
New environment variable DENY_REDIS_BUFFERS to stop storing logs in
redis overall. The value must be set to `no_redis` in order deny redis
buffers.