### PR TITLE
control rod to stop drain forwarding

### DIFF
--- a/src/logplex_app.erl
+++ b/src/logplex_app.erl
@@ -147,6 +147,9 @@ cache_os_envvars() ->
                      ,{disable_redgrid, ["DISABLE_REDGRID"],
                        optional,
                        atom}
+                     ,{disable_drain_forwarding, ["DISABLE_DRAIN_FORWARDING"],
+                       optional,
+                       atom}
                      ]),
     ok.
 


### PR DESCRIPTION
Setting the `DISABLE_DRAIN_FORWARDING` env var to `true` will stop all
forwarding to drains. Setting the `deny_drain_forwarding` application
var on a running system to instantly kill all new traffic to drains.

Drains will still continue to send any data that has been buffered until
the buffers are cleared out.