### PR TITLE
Add control rod for logs ingress

### DIFF
--- a/src/logplex_app.erl
+++ b/src/logplex_app.erl
@@ -153,6 +153,9 @@ cache_os_envvars() ->
                      ,{disable_firehose, ["DISABLE_FIREHOSE"],
                        optional,
                        atom}
+                     ,{deny_logs_ingress, ["DENY_LOGS_INGRESS"],
+                       optional,
+                       atom}
                      ]),
     ok.
 

--- a/src/logplex_logs_rest.erl
+++ b/src/logplex_logs_rest.erl
@@ -11,6 +11,7 @@
 
 -export([init/3
          ,rest_init/2
+         ,service_available/2
          ,allowed_methods/2
          ,is_authorized/2
          ,known_content_type/2
@@ -68,6 +69,14 @@ terminate(_, _, _) -> ok.
 %% Logs cowboy_rest implementation
 rest_init(Req, _Opts) ->
     {ok, Req, #state{}}.
+
+service_available(Req, State) ->
+    case logplex_app:config(deny_logs_ingress, false) of
+        true ->
+            {false, Req, State};
+        _ ->
+            {true, Req, State}
+    end.
 
 allowed_methods(Req, State) ->
     {[<<"POST">>], Req, State}.

--- a/test/logplex_logs_rest_SUITE.erl
+++ b/test/logplex_logs_rest_SUITE.erl
@@ -54,7 +54,7 @@ end_per_testcase(Case, Config)
     meck:unload(logplex_message),
     Config;
 end_per_testcase(service_unavailable, Config) ->
-    logplex_app:set_config(deny_logs_ingress, true),
+    logplex_app:set_config(deny_logs_ingress, false),
     Config;
 end_per_testcase(_Case, Config) ->
     Config.


### PR DESCRIPTION
New environment variable DENY_LOGS_INGRESS. When set to "true" the logs
endpoint return 503 Service Unavailable for all requests.