### PR TITLE
Implement endpoint for channel logs

### DIFF
--- a/src/logplex_api_v3.erl
+++ b/src/logplex_api_v3.erl
@@ -19,11 +19,12 @@
          done/4
         ]).
 
--define(HEALTHCHECK_PATH, "/v3/healthcheck").
--define(CHANNELS_PATH,    "/v3/channels/:channel_id").
--define(DRAINS_PATH,      "/v3/channels/:channel_id/drains/[:drain_id]").
--define(TOKENS_PATH,      "/v3/channels/:channel_id/tokens").
--define(SESSIONS_PATH,    "/v3/sessions/[:session_id]").
+-define(HEALTHCHECK_PATH,  "/v3/healthcheck").
+-define(CHANNELS_PATH,     "/v3/channels/:channel_id").
+-define(DRAINS_PATH,       "/v3/channels/:channel_id/drains/[:drain_id]").
+-define(TOKENS_PATH,       "/v3/channels/:channel_id/tokens").
+-define(CHANNEL_LOGS_PATH, "/v3/channels/:channel_id/logs").
+-define(SESSIONS_PATH,     "/v3/sessions/[:session_id]").
 
 -define(BASIC_AUTH, <<"Basic realm=Logplex">>).
 -define(REQUEST_ID_HEADER_KEY, <<"request-id">>).
@@ -49,7 +50,8 @@ dispatch() ->
                              channels_path(),
                              drains_path(),
                              sessions_path(),
-                             tokens_path()
+                             tokens_path(),
+                             channel_logs_path()
                             ]}]).
 
 healthcheck_path() ->
@@ -67,6 +69,8 @@ sessions_path() ->
 tokens_path() ->
     {?TOKENS_PATH, logplex_api_v3_tokens, [{route, ?TOKENS_PATH}]}.
 
+channel_logs_path() ->
+    {?CHANNEL_LOGS_PATH, logplex_api_v3_channel_logs, [{route, ?CHANNEL_LOGS_PATH}]}.
 
 %% ----------------------------------------------------------------------------
 %% REST helpers
@@ -232,6 +236,7 @@ maybe_get_endpoint(?CHANNELS_PATH) -> "channels";
 maybe_get_endpoint(?DRAINS_PATH) -> "drains";
 maybe_get_endpoint(?SESSIONS_PATH) -> "sessions";
 maybe_get_endpoint(?TOKENS_PATH) -> "tokens";
+maybe_get_endpoint(?CHANNEL_LOGS_PATH) -> "channel_logs";
 maybe_get_endpoint(_) -> "unknown_resource".
 
 resp_code_group(Status) when Status >= 200, Status < 300 -> "2xx";

--- a/src/logplex_api_v3_channel_logs.erl
+++ b/src/logplex_api_v3_channel_logs.erl
@@ -1,0 +1,90 @@
+-module(logplex_api_v3_channel_logs).
+
+-include("logplex.hrl").
+-include("logplex_channel.hrl").
+-include("logplex_logging.hrl").
+
+-export([init/3,
+         rest_init/2,
+         service_available/2,
+         allowed_methods/2,
+         is_authorized/2,
+         resource_exists/2,
+         content_types_provided/2,
+         to_logs/2
+        ]).
+
+-record(state, {
+          channel_id :: binary()
+         }).
+
+%% @private
+init(_Transport, Req, Opts) ->
+    Route = proplists:get_value(route, Opts),
+    Req1 = logplex_api_v3:prepare(Route, Req),
+    {upgrade, protocol, cowboy_rest, Req1, Opts}.
+
+%% @private
+rest_init(Req, _Opts) ->
+    {ChannelId, Req1} = cowboy_req:binding(channel_id, Req),
+    State = #state{ channel_id = ChannelId },
+    {ok, Req1, State}.
+
+%% @private
+service_available(Req, State) ->
+    logplex_api_v3:service_available(Req, State).
+
+%% @private
+allowed_methods(Req, State) ->
+    {[<<"GET">>], Req, State}.
+
+%% @private
+is_authorized(Req, State) ->
+    logplex_api_v3:is_authorized(Req, State).
+
+%% @private
+resource_exists(Req, #state{ channel_id = ChannelId } = State) ->
+    case logplex_channel:find(ChannelId) of
+        {ok, _Channel} ->
+            {true, Req, State};
+        {error, not_found} ->
+            %% channel was not found
+            {false, Req, State}
+    end.
+
+%% @private
+content_types_provided(Req, State) ->
+    {[{{<<"application">>, <<"logplex-1">>, []}, to_logs}], Req, State}.
+
+%% @private
+to_logs(Req, #state{ channel_id = ChannelId } = State) ->
+    %% fetch all messages from log buffer
+    case logplex_channel:logs(ChannelId, -1) of
+        {error, Reason} ->
+            ?ERR("channel_id=~s err='failed to fetch channel logs' reason='~p'",
+                 [ChannelId, Reason]),
+            Resp = jsx:encode([{<<"error">>, <<"failed to fetch channel logs">>}]),
+            Req1 = cowboy_req:set_resp_body(Resp, Req),
+            {ok, Req2} = cowboy_req:reply(500, Req1),
+            {halt, Req2, State};
+        Logs when is_list(Logs) ->
+            %% Cowboy hands us the function to write a chunk, here we need to return
+            %% a function that passes our chunks to the chunk writer.
+            ChunkedFun = fun(WriteChunkFun) -> serve_logs(Logs, WriteChunkFun) end,
+            MsgCount = length(Logs),
+            Req1 = cowboy_req:set_resp_header(<<"logplex-msg-count">>, integer_to_list(MsgCount), Req),
+            Req2 = cowboy_req:set_resp_header(<<"connection">>, <<"close">>, Req1),
+            {{chunked, ChunkedFun}, Req2, State}
+    end.
+
+serve_logs(Logs, WriteChunkFun) ->
+    [WriteChunkFun(Msg) || Msg <- prepare_logs(Logs, [])],
+    ok.
+
+prepare_logs([], Acc) ->
+    Acc;
+prepare_logs([Msg | Logs], Acc) ->
+    prepare_logs(Logs, [prepare_msg(Msg) | Acc]).
+
+prepare_msg(Msg) ->
+    logplex_utils:format(logplex_utils:parse_msg(Msg)).

--- a/test/logplex_api_SUITE.erl
+++ b/test/logplex_api_SUITE.erl
@@ -268,13 +268,16 @@ request(Method, Url, Opts) ->
 
 wait_for_http(RequestId, Headers, Body) ->
     receive
-        {http, {RequestId, stream_start, Headers}} ->
-            wait_for_http(RequestId, Headers, Body);
+        {http, {RequestId0, stream_start, Headers0}} ->
+            wait_for_http(RequestId0, Headers0, Body);
         {http, {RequestId, stream, BinBody}} ->
             Body0 = binary_to_list(BinBody),
             wait_for_http(RequestId, Headers, Body++Body0);
         {http, {RequestId, stream_end, Headers0}} ->
-            {Headers++Headers0, Body}
+            {Headers++Headers0, Body};
+        {http, Msg} ->
+            ct:fail("unexpected http message: ~p~n", [Msg]),
+            {error, unexpected_http_msg, Msg}
     end.
 
 wait_for_messages(Channel, MessageAmount, MaxWait, StartTime) ->


### PR DESCRIPTION
## Rationale

This new v3 API endpoint allows to fetch all buffered logs of a channel at once. 

## Changes
* impelment new endpoint `v3/channels/:id/logs`
* test new endpoint