### PR TITLE
increase drain limit to 6 from 5

### DIFF
--- a/src/logplex.app.src
+++ b/src/logplex.app.src
@@ -59,7 +59,7 @@
     ,{log_history, 1500}
     ,{log_unknown_tokens, false} % bool
     ,{logplex_shard_urls, "redis://localhost:6379"}
-    ,{max_drains_per_channel, 5} % #channels
+    ,{max_drains_per_channel, 6} % #channels
     ,{metrics_namespace, "dev"} % string, no spaces
     ,{no_tail_warning,
       "Error L20 (Tail sessions forbidden) "


### PR DESCRIPTION
As part of log-tails, there might be apps with 5 drains already, and we wouldn't be able to add the log-tails required drain there.

We'll need to increase this limit to 6. API still maintains `limit=5` so we're good on the public facing front.