### PR TITLE
Fix v3 API status handling

### DIFF
--- a/src/logplex_api.erl
+++ b/src/logplex_api.erl
@@ -738,10 +738,10 @@ status() ->
 set_status(Term) ->
     Old = status(),
     case Term of
-        normal -> io:format("Fully Enabling API~n");
-        read_only -> io:format("API in read-only mode: only GET requests and "
+        normal -> io:format("Enabling legacy API~n");
+        read_only -> io:format("Legacy API in read-only mode: only GET requests and "
                                "canary operations allowed.~n");
-        disabled -> io:format("API entirely disabled~n")
+        disabled -> io:format("Legacy API entirely disabled~n")
     end,
     logplex_app:set_config(legacy_api_status, Term),
     Old.

--- a/src/logplex_app.erl
+++ b/src/logplex_app.erl
@@ -78,6 +78,7 @@ stop(_State) ->
     ok.
 
 start_phase(listen, normal, _Args) ->
+    logplex_api_v3:set_status(logplex_api_v3:status()),
     logplex_api:set_status(logplex_api:status()),
     setup_firehose(),
     {ok, _} = supervisor:start_child(logplex_sup,

--- a/src/logplex_control_rods.erl
+++ b/src/logplex_control_rods.erl
@@ -147,7 +147,7 @@ status_to_value(disable_redgrid) ->
         normal -> 0
     end;
 status_to_value(disable_api) ->
-    case logplex_api:status() of
+    case logplex_api_v3:status() of
         normal -> 0;
         read_only -> 1;
         disabled -> 1


### PR DESCRIPTION
When we split the status handling of v3 and legacy API control rods were measuring only legacy status. Now we only measure v3 API status. Legacy API is deprecated and won't need to be checked.