### PR TITLE
Fix redis read reconnects

### DIFF
--- a/src/logplex_shard.erl
+++ b/src/logplex_shard.erl
@@ -331,7 +331,7 @@ redis_buffer_opts(Url) ->
 handle_child_death(Pid) ->
     case logplex_shard_info:pid_info(Pid) of
         {logplex_read_pool_map, {{Shard, {Url, Pid}}, Map, V}} ->
-            {ok, NewPid} = add_pool_with_retry(Url, 10),
+            {ok, NewPid} = add_pool_with_retry(Url, 60),
             NewMap = dict:store(Shard, {Url, NewPid}, Map),
             logplex_shard_info:save(logplex_read_pool_map, NewMap, V),
             ?INFO("at=read_pool_restart oldpid=~p newpid=~p",

--- a/src/logplex_shard.erl
+++ b/src/logplex_shard.erl
@@ -331,7 +331,7 @@ redis_buffer_opts(Url) ->
 handle_child_death(Pid) ->
     case logplex_shard_info:pid_info(Pid) of
         {logplex_read_pool_map, {{Shard, {Url, Pid}}, Map, V}} ->
-            NewPid = add_pool_with_retry(Url, 10),
+            {ok, NewPid} = add_pool_with_retry(Url, 10),
             NewMap = dict:store(Shard, {Url, NewPid}, Map),
             logplex_shard_info:save(logplex_read_pool_map, NewMap, V),
             ?INFO("at=read_pool_restart oldpid=~p newpid=~p",


### PR DESCRIPTION
There was a mismatch here when reconnects run out of retries and `{error, out_of_retries}` would be returned for `NewPid` which would end up in the reader map. This change ensures a connection was established within 5 minutes. If this retry period is exhausted the entire process crashes and would attempt to re-establish all (reader and writer) connections after a supervisor restart.