### PR TITLE
docs: Add 429 mention in `handle_response_status` docs.

### DIFF
--- a/src/logplex_http_drain.erl
+++ b/src/logplex_http_drain.erl
@@ -371,7 +371,7 @@ try_send(Frame = #frame{tries = 0, msg_count=C}, State = #state{}) ->
     ready_to_send(drop_frame(Frame, State)).
 
 %% @private Decide what happened to the frame based on the http status
-%% code. Back of the napkin algorithm - 2xx is success, 4xx (client
+%% code. Back of the napkin algorithm - 2xx is success, 4xx, except 429 (client
 %% errors) are perm failures, so drop the frame and anything else is a
 %% temp failure, so retry the frame.
 handle_response_status(Status, Frame, State, _Latency) when 200 =< Status, Status < 300 ->


### PR DESCRIPTION
Was trying to help answer a question about how logplex do today and
I noticed that we were missing the 429 case in this note.

Slack Chat: https://heroku.slack.com/archives/C2LA11J4S/p1543340768685200