### PR TITLE
Adjust redis writer restart intensity

### DIFF
--- a/src/logplex_redis_writer.erl
+++ b/src/logplex_redis_writer.erl
@@ -93,7 +93,7 @@ write_queued_logs(BufferPid, Socket) ->
             end;
         Else ->
             ?WARN("event=queue_out result=~p", [Else]),
-            exit(normal)
+            exit({error, {unexpected_result, Else}})
     end.
 
 check_for_stop_signal() ->

--- a/src/logplex_sup.erl
+++ b/src/logplex_sup.erl
@@ -60,7 +60,8 @@ init([]) ->
        ,{logplex_redis_writer_sup,
          {logplex_worker_sup, start_link,
           [logplex_redis_writer_sup, logplex_redis_writer]},
-         permanent, 2000, worker, [logplex_redis_writer_sup]}
+         permanent, 2000, supervisor, [logplex_redis_writer_sup]}
+
        ,{logplex_redis_reader_sup,
          {logplex_redis_reader_sup, start_link, []},
          permanent, 2000, supervisor, [logplex_redis_reader_sup]}

--- a/src/logplex_worker_sup.erl
+++ b/src/logplex_worker_sup.erl
@@ -32,6 +32,6 @@ start_child(Name, Args) ->
     supervisor:start_child(Name, Args).
 
 init([Mod]) ->
-    {ok, {{simple_one_for_one, 1000, 1}, [
+    {ok, {{simple_one_for_one, 15000, 30}, [
         {Mod, {Mod, start_link, []}, transient, 2000, worker, [Mod]}
     ]}}.


### PR DESCRIPTION
## Rationale 

The redis writers connectivity appears unreliable.

## Changes
* extend redis writer restart intensity to 15000 restarts within 30 seconds 
* add some housekeeping for redis writers in logplex_queue
* don't let the writer exit normally on unexpected responses from a logplex_queue process

## Details
The prior restart intensity of the redis writer supervisor configuration did allow for 1000 restarts per 1 second. This is problematic for restarting redis writers, for example, when there are 100 shards and 10 writers per shard. On a network connectivity problem the number of restarts gets easily exceeded which forces a redis writer supervisor restart. After a supervisor restart all prior created connection information is lost. Without manual intervention the connection information is not automatically recovered.

The logplex_queue processes hold a list of workers for book keeping. This list doesn't have a function except for introspection. Without the change here this list becomes outdated as writer connections to redis go away.

A redis writer process would exit normally which prevents a automatic restart by the supervisor on unexpected errors when fetching messages from its logplex_queue process.