### PR TITLE
Avoid regrid supervisor start when redgrid is disabled

### DIFF
--- a/src/logplex_sup.erl
+++ b/src/logplex_sup.erl
@@ -49,9 +49,16 @@ init([]) ->
          permanent, 2000, supervisor, [logplex_drain_sup]}
        ,{nsync, {nsync, start_link, [logplex_app:nsync_opts()]},
          permanent, 2000, worker, [nsync]}
-       ,{redgrid, {redgrid, start_link, []},
-         permanent, 2000, worker, [redgrid]}
-       ,{logplex_stats, {logplex_stats, start_link, []},
+      ] ++
+
+      case logplex_app:config(disable_redgrid, false) of
+          true -> [];
+          _ ->
+              [{redgrid, {redgrid, start_link, []},
+                permanent, 2000, worker, [redgrid]}]
+      end ++
+
+      [{logplex_stats, {logplex_stats, start_link, []},
          permanent, 2000, worker, [logplex_stats]}
 
        ,{logplex_tail, {logplex_tail, start_link, []},


### PR DESCRIPTION
## Rationale
The logplex supervisor was still starting a redgrid process without checking if redgrid was enabled. This is now fixed.