### PR TITLE
Captures timeouts when looking up resources.

### DIFF
--- a/config/vm.args
+++ b/config/vm.args
@@ -3,7 +3,7 @@
 
 +K true
 +A1000
-+P 500000
++P 1000000
 
 +MBas aobf
 +MBlmbcs 512

--- a/rebar.config
+++ b/rebar.config
@@ -37,6 +37,7 @@
   ,{erlang_syslog, {git, "https://github.com/heroku/erlang_syslog", {branch, "library"}}}
   ,{poolboy, "1.5.1"}
   ,{backoff, "1.1.6"}
+  ,{observer_cli, "1.4.4"}
  ]}.
 
 {ct_compile_opts,

--- a/rebar.lock
+++ b/rebar.lock
@@ -67,6 +67,7 @@
   {git,"https://github.com/heroku/nsync.git",
        {ref,"df46d5315b94d71942599f15ff3187795e195085"}},
   0},
+ {<<"observer_cli">>,{pkg,<<"observer_cli">>,<<"1.4.4">>},0},
  {<<"pagerduty">>,
   {git,"https://github.com/heroku/pagerduty.git",
        {ref,"36e4b95cdd05d309ff5aea9f01914b86bcce5d17"}},
@@ -110,5 +111,6 @@
   0}]}.
 [
 {pkg_hash,[
+ {<<"observer_cli">>, <<"DF1264B5871BBAF8DA4F11FEADFA0DC661F4D511493A25F8F9C7D615E0D614D5">>},
  {<<"poolboy">>, <<"6B46163901CFD0A1B43D692657ED9D7E599853B3B21B95AE5AE0A777CF9B6CA8">>}]}
 ].

--- a/relx.config
+++ b/relx.config
@@ -2,6 +2,7 @@
 {release, {logplex, "v89"},
  [logplex
   ,heroku_crashdumps
+  ,observer_cli
   ,recon]}.
 
 {sys_config, "./config/sys.config"}.

--- a/src/logplex_api_v3_channel_logs.erl
+++ b/src/logplex_api_v3_channel_logs.erl
@@ -65,6 +65,10 @@ resource_exists(Req, #state{ channel_id = ChannelId } = State) ->
     case logplex_channel:find(ChannelId) of
         {ok, _Channel} ->
             {true, Req, State};
+        {error, timeout} ->
+            ?WARN("at=resource_exists channel_id=~s error=channel_find_timeout", [ChannelId]),
+            {ok, Req2} = cowboy_req:reply(500, Req),
+            {halt, Req2, State};
         {error, not_found} ->
             %% channel was not found
             {false, Req, State}

--- a/src/logplex_api_v3_channels.erl
+++ b/src/logplex_api_v3_channels.erl
@@ -57,6 +57,10 @@ resource_exists(Req, #state{ channel_id = ChannelId } = State) ->
                                     tokens  = Tokens,
                                     drains  = Drains },
             {true, Req, NewState};
+        {error, timeout} ->
+            ?WARN("at=resource_exists channel_id=~s error=channel_find_timeout", [ChannelId]),
+            {ok, Req2} = cowboy_req:reply(500, Req),
+            {halt, Req2, State};
         {error, not_found} ->
             %% channel was not found
             {false, Req, State}

--- a/src/logplex_api_v3_drains.erl
+++ b/src/logplex_api_v3_drains.erl
@@ -110,10 +110,19 @@ resource_exists(Req, #state{ channel_id = ChannelId,
                 {ok, Drain} ->
                     NewState = State#state{ drain = Drain },
                     {true, Req, NewState};
+                {error, timeout} ->
+                    ?WARN("at=resource_exists channel_id=~s drain_id=~s error=drain_find_timeout",
+                    [ChannelId, DrainId]),
+                    {ok, Req2} = cowboy_req:reply(500, Req),
+                    {halt, Req2, State};
                 {error, not_found} ->
                     %% drain was not found for channel
                     {false, Req, State}
             end;
+        {error, timeout} ->
+            ?WARN("at=resource_exists channel_id=~s error=channel_find_timeout", [ChannelId]),
+            {ok, Req2} = cowboy_req:reply(500, Req),
+            {halt, Req2, State};
         {error, not_found} ->
             %% channel was not found
             {ok, Req1} = cowboy_req:reply(404, Req),


### PR DESCRIPTION
With this change in place timeout errors are captured and will return a 500 error. This
doesn't change the overall behaviour as the client sees things, however it prevents
a process crash in Logplex.